### PR TITLE
Fixed deleteModelInstance for the last delete of a Model Instance

### DIFF
--- a/Framework/Source/Graphics/Scene/Scene.cpp
+++ b/Framework/Source/Graphics/Scene/Scene.cpp
@@ -198,14 +198,20 @@ namespace Falcor
         // Delete instance
         auto& instances = mModels[modelID];
 
-        instances.erase(instances.begin() + instanceID);
-        mExtentsDirty = true;
-
-        // If no instances are left, delete the vector
-        if (instances.empty())
-        {
-            deleteModel(modelID);
-        }
+		//	Check if there is only one instance left.
+		if (instances.size() == 1)
+		{
+			//	Delete the entire model, since it will also erase the corresponding instance.
+			deleteModel(modelID);
+		}
+		else
+		{
+			//	Erase the instance.
+	        instances.erase(instances.begin() + instanceID);
+		}
+		
+		//	Extents will be dirty in either case.
+		mExtentsDirty = true;
     }
 
     const Scene::UserVariable& Scene::getUserVariable(const std::string& name)


### PR DESCRIPTION
Would try and access the model from the last instance after wiping all the instances. Now checks if there is only one remaining instance and deletes the entire Model. 