### PR TITLE
Vulkan slang reflection

### DIFF
--- a/Framework/Externals/slang/slang.h
+++ b/Framework/Externals/slang/slang.h
@@ -224,6 +224,19 @@ extern "C"
         SlangSourceLanguage     language,
         char const*             name);
 
+    /** Add a preprocessor definition that is scoped to a single translation unit.
+
+    @param translationUnitIndex The index of the translation unit to get the definition.
+    @param key The name of the macro to define.
+    @param value The value of the macro to define.
+    */
+    SLANG_API void spTranslationUnit_addPreprocessorDefine(
+        SlangCompileRequest*    request,
+        int                     translationUnitIndex,
+        const char*             key,
+        const char*             value);
+
+
     /** Add a source file to the given translation unit
     */
     SLANG_API void spAddTranslationUnitSourceFile(

--- a/Framework/Externals/slang/source/slang/compiler.cpp
+++ b/Framework/Externals/slang/source/slang/compiler.cpp
@@ -53,606 +53,501 @@ namespace Slang
 
         //
 
-        int compilerInstances = 0;
-
-        class ShaderCompilerImpl : public ShaderCompiler
+        String EmitHLSL(ExtraContext& context)
         {
-        public:
-
-            // Actual context for compilation... :(
-            struct ExtraContext
+            if (context.getOptions().passThrough != PassThroughMode::None)
             {
-                CompileOptions const* options = nullptr;
-                TranslationUnitOptions const* translationUnitOptions = nullptr;
-
-                CompileResult* compileResult = nullptr;
-
-                RefPtr<ProgramSyntaxNode>   programSyntax;
-                ProgramLayout*              programLayout;
-
-                String sourceText;
-                String sourcePath;
-
-                CompileOptions const& getOptions() { return *options; }
-                TranslationUnitOptions const& getTranslationUnitOptions() { return *translationUnitOptions; }
-            };
-
-
-            String EmitHLSL(ExtraContext& context)
-            {
-                if (context.getOptions().passThrough != PassThroughMode::None)
-                {
-                    return context.sourceText;
-                }
-                else
-                {
-                    // TODO(tfoley): probably need a way to customize the emit logic...
-                    return emitProgram(
-                        context.programSyntax.Ptr(),
-                        context.programLayout,
-                        CodeGenTarget::HLSL);
-                }
+                return context.sourceText;
             }
-
-            String emitGLSLForEntryPoint(ExtraContext& context, EntryPointOption const& entryPoint)
+            else
             {
-                if (context.getOptions().passThrough != PassThroughMode::None)
-                {
-                    return context.sourceText;
-                }
-                else
-                {
-                    // TODO(tfoley): probably need a way to customize the emit logic...
-                    return emitProgram(
-                        context.programSyntax.Ptr(),
-                        context.programLayout,
-                        CodeGenTarget::GLSL);
-                }
+                // TODO(tfoley): probably need a way to customize the emit logic...
+                return emitProgram(
+                    context.programSyntax.Ptr(),
+                    context.programLayout,
+                    CodeGenTarget::HLSL);
             }
+        }
 
-            char const* GetHLSLProfileName(Profile profile)
+        String emitGLSLForEntryPoint(ExtraContext& context, EntryPointOption const& /*entryPoint*/)
+        {
+            if (context.getOptions().passThrough != PassThroughMode::None)
             {
-                switch(profile.raw)
-                {
-                #define PROFILE(TAG, NAME, STAGE, VERSION) case Profile::TAG: return #NAME;
-                #include "profile-defs.h"
-
-                default:
-                    // TODO: emit an error here!
-                    return "unknown";
-                }
+                return context.sourceText;
             }
+            else
+            {
+                // TODO(tfoley): probably need a way to customize the emit logic...
+                return emitProgram(
+                    context.programSyntax.Ptr(),
+                    context.programLayout,
+                    CodeGenTarget::GLSL);
+            }
+        }
+
+        char const* GetHLSLProfileName(Profile profile)
+        {
+            switch(profile.raw)
+            {
+            #define PROFILE(TAG, NAME, STAGE, VERSION) case Profile::TAG: return #NAME;
+            #include "profile-defs.h"
+
+            default:
+                // TODO: emit an error here!
+                return "unknown";
+            }
+        }
 
 #ifdef _WIN32
-            void* GetD3DCompilerDLL()
+        void* GetD3DCompilerDLL()
+        {
+            // TODO(tfoley): let user specify version of d3dcompiler DLL to use.
+            static HMODULE d3dCompiler =  LoadLibraryA("d3dcompiler_47");
+            // TODO(tfoley): handle case where we can't find it gracefully
+            assert(d3dCompiler);
+            return d3dCompiler;
+        }
+
+        List<uint8_t> EmitDXBytecodeForEntryPoint(
+            ExtraContext&				context,
+            EntryPointOption const&		entryPoint)
+        {
+            static pD3DCompile D3DCompile_ = nullptr;
+            if (!D3DCompile_)
             {
-                // TODO(tfoley): let user specify version of d3dcompiler DLL to use.
-                static HMODULE d3dCompiler =  LoadLibraryA("d3dcompiler_47");
-                // TODO(tfoley): handle case where we can't find it gracefully
+                HMODULE d3dCompiler = (HMODULE)GetD3DCompilerDLL();
                 assert(d3dCompiler);
-                return d3dCompiler;
+
+                D3DCompile_ = (pD3DCompile)GetProcAddress(d3dCompiler, "D3DCompile");
+                assert(D3DCompile_);
             }
 
-            List<uint8_t> EmitDXBytecodeForEntryPoint(
-                ExtraContext&				context,
-                EntryPointOption const&		entryPoint)
+            // The HLSL compiler will try to "canonicalize" our input file path,
+            // and we don't want it to do that, because they it won't report
+            // the same locations on error messages that we would.
+            //
+            // To work around that, we prepend a custom `#line` directive.
+
+            String rawHlslCode = EmitHLSL(context);
+
+            StringBuilder hlslCodeBuilder;
+            hlslCodeBuilder << "#line 1 \"";
+            for(auto c : context.sourcePath)
             {
-                static pD3DCompile D3DCompile_ = nullptr;
-                if (!D3DCompile_)
+                char buffer[] = { c, 0 };
+                switch(c)
                 {
-                    HMODULE d3dCompiler = (HMODULE)GetD3DCompilerDLL();
-                    assert(d3dCompiler);
+                default:
+                    hlslCodeBuilder << buffer;
+                    break;
 
-                    D3DCompile_ = (pD3DCompile)GetProcAddress(d3dCompiler, "D3DCompile");
-                    assert(D3DCompile_);
+                case '\\':
+                    hlslCodeBuilder << "\\\\";
                 }
+            }
+            hlslCodeBuilder << "\"\n";
+            hlslCodeBuilder << rawHlslCode;
 
-                // The HLSL compiler will try to "canonicalize" our input file path,
-                // and we don't want it to do that, because they it won't report
-                // the same locations on error messages that we would.
-                //
-                // To work around that, we prepend a custom `#line` directive.
+            auto hlslCode = hlslCodeBuilder.ProduceString();
 
-                String rawHlslCode = EmitHLSL(context);
+            ID3DBlob* codeBlob;
+            ID3DBlob* diagnosticsBlob;
+            HRESULT hr = D3DCompile_(
+                hlslCode.begin(),
+                hlslCode.Length(),
+                context.sourcePath.begin(),
+                nullptr,
+                nullptr,
+                entryPoint.name.begin(),
+                GetHLSLProfileName(entryPoint.profile),
+                0,
+                0,
+                &codeBlob,
+                &diagnosticsBlob);
+            List<uint8_t> data;
+            if (codeBlob)
+            {
+                data.AddRange((uint8_t const*)codeBlob->GetBufferPointer(), (int)codeBlob->GetBufferSize());
+                codeBlob->Release();
+            }
+            if (diagnosticsBlob)
+            {
+                // TODO(tfoley): need a better policy for how we translate diagnostics
+                // back into the Slang world (although we should always try to generate
+                // HLSL that doesn't produce any diagnostics...)
+                String diagnostics = (char const*) diagnosticsBlob->GetBufferPointer();
+                fprintf(stderr, "%s", diagnostics.begin());
+                OutputDebugStringA(diagnostics.begin());
+                diagnosticsBlob->Release();
+            }
+            if (FAILED(hr))
+            {
+                // TODO(tfoley): What to do on failure?
+            }
+            return data;
+        }
 
-                StringBuilder hlslCodeBuilder;
-                hlslCodeBuilder << "#line 1 \"";
-                for(auto c : context.sourcePath)
+        List<uint8_t> EmitDXBytecode(
+            ExtraContext&				context)
+        {
+            if(context.getTranslationUnitOptions().entryPoints.Count() != 1)
+            {
+                if(context.getTranslationUnitOptions().entryPoints.Count() == 0)
                 {
-                    char buffer[] = { c, 0 };
-                    switch(c)
-                    {
-                    default:
-                        hlslCodeBuilder << buffer;
-                        break;
-
-                    case '\\':
-                        hlslCodeBuilder << "\\\\";
-                    }
+                    // TODO(tfoley): need to write diagnostics into this whole thing...
+                    fprintf(stderr, "no entry point specified\n");
                 }
-                hlslCodeBuilder << "\"\n";
-                hlslCodeBuilder << rawHlslCode;
-
-                auto hlslCode = hlslCodeBuilder.ProduceString();
-
-                ID3DBlob* codeBlob;
-                ID3DBlob* diagnosticsBlob;
-                HRESULT hr = D3DCompile_(
-                    hlslCode.begin(),
-                    hlslCode.Length(),
-                    context.sourcePath.begin(),
-                    nullptr,
-                    nullptr,
-                    entryPoint.name.begin(),
-                    GetHLSLProfileName(entryPoint.profile),
-                    0,
-                    0,
-                    &codeBlob,
-                    &diagnosticsBlob);
-                List<uint8_t> data;
-                if (codeBlob)
+                else
                 {
-                    data.AddRange((uint8_t const*)codeBlob->GetBufferPointer(), (int)codeBlob->GetBufferSize());
-                    codeBlob->Release();
+                    fprintf(stderr, "multiple entry points specified\n");
                 }
-                if (diagnosticsBlob)
-                {
-                    // TODO(tfoley): need a better policy for how we translate diagnostics
-                    // back into the Slang world (although we should always try to generate
-                    // HLSL that doesn't produce any diagnostics...)
-                    String diagnostics = (char const*) diagnosticsBlob->GetBufferPointer();
-                    fprintf(stderr, "%s", diagnostics.begin());
-                    OutputDebugStringA(diagnostics.begin());
-                    diagnosticsBlob->Release();
-                }
-                if (FAILED(hr))
-                {
-                    // TODO(tfoley): What to do on failure?
-                }
-                return data;
+                return List<uint8_t>();
             }
 
-            List<uint8_t> EmitDXBytecode(
-                ExtraContext&				context)
+            return EmitDXBytecodeForEntryPoint(context, context.getTranslationUnitOptions().entryPoints[0]);
+        }
+
+        String EmitDXBytecodeAssemblyForEntryPoint(
+            ExtraContext&				context,
+            EntryPointOption const&		entryPoint)
+        {
+            static pD3DDisassemble D3DDisassemble_ = nullptr;
+            if (!D3DDisassemble_)
             {
-                if(context.getTranslationUnitOptions().entryPoints.Count() != 1)
+                HMODULE d3dCompiler = (HMODULE)GetD3DCompilerDLL();
+                assert(d3dCompiler);
+
+                D3DDisassemble_ = (pD3DDisassemble)GetProcAddress(d3dCompiler, "D3DDisassemble");
+                assert(D3DDisassemble_);
+            }
+
+            List<uint8_t> dxbc = EmitDXBytecodeForEntryPoint(context, entryPoint);
+            if (!dxbc.Count())
+            {
+                return "";
+            }
+
+            ID3DBlob* codeBlob;
+            HRESULT hr = D3DDisassemble_(
+                &dxbc[0],
+                dxbc.Count(),
+                0,
+                nullptr,
+                &codeBlob);
+
+            String result;
+            if (codeBlob)
+            {
+                result = String((char const*) codeBlob->GetBufferPointer());
+                codeBlob->Release();
+            }
+            if (FAILED(hr))
+            {
+                // TODO(tfoley): need to figure out what to diagnose here...
+            }
+            return result;
+        }
+
+
+        String EmitDXBytecodeAssembly(
+            ExtraContext&				context)
+        {
+            if(context.getTranslationUnitOptions().entryPoints.Count() == 0)
+            {
+                // TODO(tfoley): need to write diagnostics into this whole thing...
+                fprintf(stderr, "no entry point specified\n");
+                return "";
+            }
+
+            StringBuilder sb;
+            for (auto entryPoint : context.getTranslationUnitOptions().entryPoints)
+            {
+                sb << EmitDXBytecodeAssemblyForEntryPoint(context, entryPoint);
+            }
+            return sb.ProduceString();
+        }
+
+
+        HMODULE getGLSLCompilerDLL()
+        {
+            // TODO(tfoley): let user specify version of glslang DLL to use.
+            static HMODULE glslCompiler =  LoadLibraryA("glslang");
+            // TODO(tfoley): handle case where we can't find it gracefully
+            assert(glslCompiler);
+            return glslCompiler;
+        }
+
+
+        String emitSPIRVAssemblyForEntryPoint(
+            ExtraContext&				context,
+            EntryPointOption const&		entryPoint)
+        {
+            String rawGLSL = emitGLSLForEntryPoint(context, entryPoint);
+
+            static glslang_CompileFunc glslang_compile = nullptr;
+            if (!glslang_compile)
+            {
+                HMODULE glslCompiler = getGLSLCompilerDLL();
+                assert(glslCompiler);
+
+                glslang_compile = (glslang_CompileFunc)GetProcAddress(glslCompiler, "glslang_compile");
+                assert(glslang_compile);
+            }
+
+            StringBuilder diagnosticBuilder;
+            StringBuilder outputBuilder;
+
+            auto outputFunc = [](char const* text, void* userData)
+            {
+                *(StringBuilder*)userData << text;
+            };
+
+            glslang_CompileRequest request;
+            request.sourcePath = context.sourcePath.begin();
+            request.sourceText = rawGLSL.begin();
+            request.slangStage = (SlangStage) entryPoint.profile.GetStage();
+
+            request.diagnosticFunc = outputFunc;
+            request.diagnosticUserData = &diagnosticBuilder;
+
+            request.outputFunc = outputFunc;
+            request.outputUserData = &outputBuilder;
+
+            int err = glslang_compile(&request);
+
+            String diagnostics = diagnosticBuilder.ProduceString();
+            String output = outputBuilder.ProduceString();
+
+            if(err)
+            {
+                OutputDebugStringA(diagnostics.Buffer());
+                fprintf(stderr, "%s", diagnostics.Buffer());
+                exit(1);
+            }
+
+            return output;
+        }
+#endif
+
+        String emitSPIRVAssembly(
+            ExtraContext&				context)
+        {
+            if(context.getTranslationUnitOptions().entryPoints.Count() == 0)
+            {
+                // TODO(tfoley): need to write diagnostics into this whole thing...
+                fprintf(stderr, "no entry point specified\n");
+                return "";
+            }
+
+            StringBuilder sb;
+            for (auto entryPoint : context.getTranslationUnitOptions().entryPoints)
+            {
+                sb << emitSPIRVAssemblyForEntryPoint(context, entryPoint);
+            }
+            return sb.ProduceString();
+        }
+
+        // Do emit logic for a single entry point
+        EntryPointResult emitEntryPoint(ExtraContext& context, EntryPointOption& entryPoint)
+        {
+            EntryPointResult result;
+
+            switch (context.getOptions().Target)
+            {
+            case CodeGenTarget::GLSL:
                 {
-                    if(context.getTranslationUnitOptions().entryPoints.Count() == 0)
+                    String code = emitGLSLForEntryPoint(context, entryPoint);
+                    result.outputSource = code;
+                }
+                break;
+
+            case CodeGenTarget::DXBytecode:
+                {
+                    auto code = EmitDXBytecodeForEntryPoint(context, entryPoint);
+
+                    // TODO(tfoley): Need to figure out an appropriate interface
+                    // for returning binary code, in addition to source.
+#if 0
+                    if (context.compileResult)
                     {
-                        // TODO(tfoley): need to write diagnostics into this whole thing...
-                        fprintf(stderr, "no entry point specified\n");
+                        StringBuilder sb;
+                        sb.Append((char*) code.begin(), code.Count());
+
+                        String codeString = sb.ProduceString();
+                        result.outputSource = codeString;
                     }
                     else
-                    {
-                        fprintf(stderr, "multiple entry points specified\n");
-                    }
-                    return List<uint8_t>();
-                }
-
-                return EmitDXBytecodeForEntryPoint(context, context.getTranslationUnitOptions().entryPoints[0]);
-            }
-
-            String EmitDXBytecodeAssemblyForEntryPoint(
-                ExtraContext&				context,
-                EntryPointOption const&		entryPoint)
-            {
-                static pD3DDisassemble D3DDisassemble_ = nullptr;
-                if (!D3DDisassemble_)
-                {
-                    HMODULE d3dCompiler = (HMODULE)GetD3DCompilerDLL();
-                    assert(d3dCompiler);
-
-                    D3DDisassemble_ = (pD3DDisassemble)GetProcAddress(d3dCompiler, "D3DDisassemble");
-                    assert(D3DDisassemble_);
-                }
-
-                List<uint8_t> dxbc = EmitDXBytecodeForEntryPoint(context, entryPoint);
-                if (!dxbc.Count())
-                {
-                    return "";
-                }
-
-                ID3DBlob* codeBlob;
-                HRESULT hr = D3DDisassemble_(
-                    &dxbc[0],
-                    dxbc.Count(),
-                    0,
-                    nullptr,
-                    &codeBlob);
-
-                String result;
-                if (codeBlob)
-                {
-                    result = String((char const*) codeBlob->GetBufferPointer());
-                    codeBlob->Release();
-                }
-                if (FAILED(hr))
-                {
-                    // TODO(tfoley): need to figure out what to diagnose here...
-                }
-                return result;
-            }
-
-
-            String EmitDXBytecodeAssembly(
-                ExtraContext&				context)
-            {
-                if(context.getTranslationUnitOptions().entryPoints.Count() == 0)
-                {
-                    // TODO(tfoley): need to write diagnostics into this whole thing...
-                    fprintf(stderr, "no entry point specified\n");
-                    return "";
-                }
-
-                StringBuilder sb;
-                for (auto entryPoint : context.getTranslationUnitOptions().entryPoints)
-                {
-                    sb << EmitDXBytecodeAssemblyForEntryPoint(context, entryPoint);
-                }
-                return sb.ProduceString();
-            }
-
-
-            HMODULE getGLSLCompilerDLL()
-            {
-                // TODO(tfoley): let user specify version of glslang DLL to use.
-                static HMODULE glslCompiler =  LoadLibraryA("glslang");
-                // TODO(tfoley): handle case where we can't find it gracefully
-                assert(glslCompiler);
-                return glslCompiler;
-            }
-
-
-            String emitSPIRVAssemblyForEntryPoint(
-                ExtraContext&				context,
-                EntryPointOption const&		entryPoint)
-            {
-                String rawGLSL = emitGLSLForEntryPoint(context, entryPoint);
-
-                static glslang_CompileFunc glslang_compile = nullptr;
-                if (!glslang_compile)
-                {
-                    HMODULE glslCompiler = getGLSLCompilerDLL();
-                    assert(glslCompiler);
-
-                    glslang_compile = (glslang_CompileFunc)GetProcAddress(glslCompiler, "glslang_compile");
-                    assert(glslang_compile);
-                }
-
-                StringBuilder diagnosticBuilder;
-                StringBuilder outputBuilder;
-
-                auto outputFunc = [](char const* text, void* userData)
-                {
-                    *(StringBuilder*)userData << text;
-                };
-
-                glslang_CompileRequest request;
-                request.sourcePath = context.sourcePath.begin();
-                request.sourceText = rawGLSL.begin();
-                request.slangStage = (SlangStage) entryPoint.profile.GetStage();
-
-                request.diagnosticFunc = outputFunc;
-                request.diagnosticUserData = &diagnosticBuilder;
-
-                request.outputFunc = outputFunc;
-                request.outputUserData = &outputBuilder;
-
-                int err = glslang_compile(&request);
-
-                String diagnostics = diagnosticBuilder.ProduceString();
-                String output = outputBuilder.ProduceString();
-
-                if(err)
-                {
-                    OutputDebugStringA(diagnostics.Buffer());
-                    fprintf(stderr, "%s", diagnostics.Buffer());
-                    exit(1);
-                }
-
-                return output;
-            }
 #endif
-
-            String emitSPIRVAssembly(
-                ExtraContext&				context)
-            {
-                if(context.getTranslationUnitOptions().entryPoints.Count() == 0)
-                {
-                    // TODO(tfoley): need to write diagnostics into this whole thing...
-                    fprintf(stderr, "no entry point specified\n");
-                    return "";
-                }
-
-                StringBuilder sb;
-                for (auto entryPoint : context.getTranslationUnitOptions().entryPoints)
-                {
-                    sb << emitSPIRVAssemblyForEntryPoint(context, entryPoint);
-                }
-                return sb.ProduceString();
-            }
-
-            // Do emit logic for a single entry point
-            EntryPointResult emitEntryPoint(ExtraContext& context, EntryPointOption& entryPoint)
-            {
-                EntryPointResult result;
-
-                switch (context.getOptions().Target)
-                {
-                case CodeGenTarget::GLSL:
                     {
-                        String code = emitGLSLForEntryPoint(context, entryPoint);
-                        result.outputSource = code;
-                    }
-                    break;
-
-                case CodeGenTarget::DXBytecode:
-                    {
-                        auto code = EmitDXBytecodeForEntryPoint(context, entryPoint);
-
-                        // TODO(tfoley): Need to figure out an appropriate interface
-                        // for returning binary code, in addition to source.
-#if 0
-                        if (context.compileResult)
+                        int col = 0;
+                        for(auto ii : code)
                         {
-                            StringBuilder sb;
-                            sb.Append((char*) code.begin(), code.Count());
-
-                            String codeString = sb.ProduceString();
-                            result.outputSource = codeString;
-                        }
-                        else
-#endif
-                        {
-                            int col = 0;
-                            for(auto ii : code)
-                            {
-                                if(col != 0) fputs(" ", stdout);
-                                fprintf(stdout, "%02X", ii);
-                                col++;
-                                if(col == 8)
-                                {
-                                    fputs("\n", stdout);
-                                    col = 0;
-                                }
-                            }
-                            if(col != 0)
+                            if(col != 0) fputs(" ", stdout);
+                            fprintf(stdout, "%02X", ii);
+                            col++;
+                            if(col == 8)
                             {
                                 fputs("\n", stdout);
+                                col = 0;
                             }
                         }
-                        return result;
-                    }
-                    break;
-
-                case CodeGenTarget::DXBytecodeAssembly:
-                    {
-                        String code = EmitDXBytecodeAssemblyForEntryPoint(context, entryPoint);
-                        result.outputSource = code;
-                    }
-                    break;
-
-                case CodeGenTarget::SPIRVAssembly:
-                    {
-                        String code = emitSPIRVAssemblyForEntryPoint(context, entryPoint);
-                        result.outputSource = code;
-                    }
-                    break;
-
-                // Note(tfoley): We currently hit this case when compiling the stdlib
-                case CodeGenTarget::Unknown:
-                    break;
-
-                default:
-                    throw "unimplemented";
-                }
-
-                return result;
-
-
-            }
-
-            TranslationUnitResult emitTranslationUnitEntryPoints(ExtraContext& context)
-            {
-                TranslationUnitResult result;
-
-                for (auto& entryPoint : context.getTranslationUnitOptions().entryPoints)
-                {
-                    EntryPointResult entryPointResult = emitEntryPoint(context, entryPoint);
-
-                    result.entryPoints.Add(entryPointResult);
-                }
-
-                // The result for the translation unit will just be the concatenation
-                // of the results for each entry point. This doesn't actually make
-                // much sense, but it is good enough for now.
-                StringBuilder sb;
-                for (auto& entryPointResult : result.entryPoints)
-                {
-                    sb << entryPointResult.outputSource;
-                }
-
-                result.outputSource = sb.ProduceString();
-
-                return result;
-            }
-
-            // Do emit logic for an entire translation unit, which might
-            // have zero or more entry points
-            TranslationUnitResult emitTranslationUnit(ExtraContext& context)
-            {
-                // Most of our code generation targets will require us
-                // to proceed through one entry point at a time, but
-                // in some cases we can emit an entire translation unit
-                // in one go.
-
-                switch (context.getOptions().Target)
-                {
-                default:
-                    // The default behavior is going to loop over all the entry
-                    // points, and then collect an aggregate result.
-                    return emitTranslationUnitEntryPoints(context);
-
-                case CodeGenTarget::HLSL:
-                    // When targetting HLSL, we can emit the entire translation unit
-                    // as a single HLSL program, and include all the entry points.
-                    {
-
-                        String hlsl = EmitHLSL(context);
-
-                        TranslationUnitResult result;
-                        result.outputSource = hlsl;
-
-                        // Because the user might ask for per-entry-point source,
-                        // we will just attach the same string as the result for
-                        // each entry point.
-                        for( auto& entryPoint : context.getTranslationUnitOptions().entryPoints )
+                        if(col != 0)
                         {
-                            (void)entryPoint;
-
-                            EntryPointResult entryPointResult;
-                            entryPointResult.outputSource = hlsl;
-                            result.entryPoints.Add(entryPointResult);
+                            fputs("\n", stdout);
                         }
-
-                        return result;
                     }
-                    break;
+                    return result;
                 }
+                break;
+
+            case CodeGenTarget::DXBytecodeAssembly:
+                {
+                    String code = EmitDXBytecodeAssemblyForEntryPoint(context, entryPoint);
+                    result.outputSource = code;
+                }
+                break;
+
+            case CodeGenTarget::SPIRVAssembly:
+                {
+                    String code = emitSPIRVAssemblyForEntryPoint(context, entryPoint);
+                    result.outputSource = code;
+                }
+                break;
+
+            // Note(tfoley): We currently hit this case when compiling the stdlib
+            case CodeGenTarget::Unknown:
+                break;
+
+            default:
+                throw "unimplemented";
             }
 
-            TranslationUnitResult DoNewEmitLogic(ExtraContext& context)
-            {
-                TranslationUnitResult result = emitTranslationUnit(context);
-
-                // As a bit of a hack, we include a mode where we just
-                // print things to standard output, so that we can see them
-                //
-                // TODO(tfoley): Is this path ever needed/used?
-                if( !context.compileResult )
-                {
-                    fprintf(stdout, "%s", result.outputSource.Buffer());
-                }
-
-                return result;
-            }
-
-            void DoNewEmitLogic(
-                ExtraContext&                   context,
-                CollectionOfTranslationUnits*   collectionOfTranslationUnits)
-            {
-                switch (context.getOptions().Target)
-                {
-                default:
-                    // For most targets, we will do things per-translation-unit
-                    for( auto translationUnit : collectionOfTranslationUnits->translationUnits )
-                    {
-                        ExtraContext innerContext = context;
-                        innerContext.translationUnitOptions = &translationUnit.options;
-                        innerContext.programSyntax = translationUnit.SyntaxNode;
-                        innerContext.sourcePath = "slang"; // don't have this any more!
-                        innerContext.sourceText = "";
-
-                        TranslationUnitResult translationUnitResult = DoNewEmitLogic(innerContext);
-                        context.compileResult->translationUnits.Add(translationUnitResult);
-                    }
-                    break;
-
-                case CodeGenTarget::ReflectionJSON:
-                    {
-                        String reflectionJSON = emitReflectionJSON(context.programLayout);
-
-                        // HACK(tfoley): just print it out since that is what people probably expect.
-                        // TODO: need a way to control where output gets routed across all possible targets.
-                        fprintf(stdout, "%s", reflectionJSON.begin());
-                    }
-                    break;
-                }
-            }
-
-            virtual void Compile(
-                CompileResult&                  result,
-                CollectionOfTranslationUnits*   collectionOfTranslationUnits,
-                const CompileOptions&           options) override
-            {
-                RefPtr<SyntaxVisitor> visitor = CreateSemanticsVisitor(result.GetErrorWriter(), options);
-                try
-                {
-                    for( auto& translationUnit : collectionOfTranslationUnits->translationUnits )
-                    {
-                        visitor->setSourceLanguage(translationUnit.options.sourceLanguage);
-
-                        translationUnit.SyntaxNode->Accept(visitor.Ptr());
-                    }
-                    if (result.GetErrorCount() > 0)
-                        return;
-
-                    // Do binding generation, and then reflection (globally)
-                    // before we move on to any code-generation activites.
-                    GenerateParameterBindings(collectionOfTranslationUnits);
+            return result;
 
 
-                    // HACK(tfoley): for right now I just want to pretty-print an AST
-                    // into another language, so the whole compiler back-end is just
-                    // getting in the way.
-                    //
-                    // I'm going to bypass it for now and see what I can do:
+        }
 
-                    ExtraContext extra;
-                    extra.options = &options;
-                    extra.programLayout = collectionOfTranslationUnits->layout.Ptr();
-                    extra.compileResult = &result;
-                    DoNewEmitLogic(extra, collectionOfTranslationUnits);
-                }
-                catch (int)
-                {
-                }
-                catch (...)
-                {
-                    throw;
-                }
-                return;
-            }
-
-            ShaderCompilerImpl()
-            {
-                if (compilerInstances == 0)
-                {
-                    BasicExpressionType::Init();
-                }
-                compilerInstances++;
-            }
-
-            ~ShaderCompilerImpl()
-            {
-                compilerInstances--;
-                if (compilerInstances == 0)
-                {
-                    BasicExpressionType::Finalize();
-                    SlangStdLib::Finalize();
-                }
-            }
-
-            virtual TranslationUnitResult PassThrough(
-                String const&			sourceText,
-                String const&			sourcePath,
-                const CompileOptions &	options,
-                TranslationUnitOptions const& translationUnitOptions) override
-            {
-                ExtraContext extra;
-                extra.options = &options;
-                extra.translationUnitOptions = &translationUnitOptions;
-                extra.sourcePath = sourcePath;
-                extra.sourceText = sourceText;
-
-                return DoNewEmitLogic(extra);
-            }
-
-        };
-
-        ShaderCompiler * CreateShaderCompiler()
+        TranslationUnitResult emitTranslationUnitEntryPoints(ExtraContext& context)
         {
-            return new ShaderCompilerImpl();
+            TranslationUnitResult result;
+
+            for (auto& entryPoint : context.getTranslationUnitOptions().entryPoints)
+            {
+                EntryPointResult entryPointResult = emitEntryPoint(context, entryPoint);
+
+                result.entryPoints.Add(entryPointResult);
+            }
+
+            // The result for the translation unit will just be the concatenation
+            // of the results for each entry point. This doesn't actually make
+            // much sense, but it is good enough for now.
+            StringBuilder sb;
+            for (auto& entryPointResult : result.entryPoints)
+            {
+                sb << entryPointResult.outputSource;
+            }
+
+            result.outputSource = sb.ProduceString();
+
+            return result;
+        }
+
+        // Do emit logic for an entire translation unit, which might
+        // have zero or more entry points
+        TranslationUnitResult emitTranslationUnit(ExtraContext& context)
+        {
+            // Most of our code generation targets will require us
+            // to proceed through one entry point at a time, but
+            // in some cases we can emit an entire translation unit
+            // in one go.
+
+            switch (context.getOptions().Target)
+            {
+            default:
+                // The default behavior is going to loop over all the entry
+                // points, and then collect an aggregate result.
+                return emitTranslationUnitEntryPoints(context);
+
+            case CodeGenTarget::HLSL:
+                // When targetting HLSL, we can emit the entire translation unit
+                // as a single HLSL program, and include all the entry points.
+                {
+
+                    String hlsl = EmitHLSL(context);
+
+                    TranslationUnitResult result;
+                    result.outputSource = hlsl;
+
+                    // Because the user might ask for per-entry-point source,
+                    // we will just attach the same string as the result for
+                    // each entry point.
+                    for( auto& entryPoint : context.getTranslationUnitOptions().entryPoints )
+                    {
+                        (void)entryPoint;
+
+                        EntryPointResult entryPointResult;
+                        entryPointResult.outputSource = hlsl;
+                        result.entryPoints.Add(entryPointResult);
+                    }
+
+                    return result;
+                }
+                break;
+            }
+        }
+
+        TranslationUnitResult generateOutput(ExtraContext& context)
+        {
+            TranslationUnitResult result = emitTranslationUnit(context);
+            return result;
+        }
+
+        void generateOutput(
+            ExtraContext&                   context,
+            CollectionOfTranslationUnits*   collectionOfTranslationUnits)
+        {
+            switch (context.getOptions().Target)
+            {
+            default:
+                // For most targets, we will do things per-translation-unit
+                for( auto translationUnit : collectionOfTranslationUnits->translationUnits )
+                {
+                    ExtraContext innerContext = context;
+                    innerContext.translationUnitOptions = &translationUnit.options;
+                    innerContext.programSyntax = translationUnit.SyntaxNode;
+                    innerContext.sourcePath = "slang"; // don't have this any more!
+                    innerContext.sourceText = "";
+
+                    TranslationUnitResult translationUnitResult = generateOutput(innerContext);
+                    context.compileResult->translationUnits.Add(translationUnitResult);
+                }
+                break;
+
+            case CodeGenTarget::ReflectionJSON:
+                {
+                    String reflectionJSON = emitReflectionJSON(context.programLayout);
+
+                    // HACK(tfoley): just print it out since that is what people probably expect.
+                    // TODO: need a way to control where output gets routed across all possible targets.
+                    fprintf(stdout, "%s", reflectionJSON.begin());
+                }
+                break;
+            }
+        }
+
+        TranslationUnitResult passThrough(
+            String const&			sourceText,
+            String const&			sourcePath,
+            const CompileOptions &	options,
+            TranslationUnitOptions const& translationUnitOptions)
+        {
+            ExtraContext extra;
+            extra.options = &options;
+            extra.translationUnitOptions = &translationUnitOptions;
+            extra.sourcePath = sourcePath;
+            extra.sourceText = sourceText;
+
+            return generateOutput(extra);
         }
 
     }

--- a/Framework/Externals/slang/source/slang/lexer.cpp
+++ b/Framework/Externals/slang/source/slang/lexer.cpp
@@ -99,38 +99,147 @@ namespace Slang
 
         enum { kEOF = -1 };
 
-        static int peek(Lexer* lexer)
+        // Get the next input byte, without any handling of
+        // escaped newlines, non-ASCII code points, source locations, etc.
+        static int peekRaw(Lexer* lexer)
         {
+            // If we are at the end of the input, return a designated end-of-file value
             if(lexer->cursor == lexer->end)
                 return kEOF;
 
+            // Otherwise, just look at the next byte
             return *lexer->cursor;
         }
 
-        static int advance(Lexer* lexer)
+        // Read one input byte without any special handling (similar to `peekRaw`)
+        static int advanceRaw(Lexer* lexer)
         {
-            if(lexer->cursor == lexer->end)
+            // The logic here is basically the same as for `peekRaw()`,
+            // escape we advance `cursor` if we aren't at the end.
+
+            if (lexer->cursor == lexer->end)
                 return kEOF;
 
-            lexer->loc.Col++;
-            lexer->loc.Pos++;
-
             return *lexer->cursor++;
+        }
+
+        // When the cursor is already at the first byte of an end-of-line sequence,
+        // consume one or two bytes that compose the sequence.
+        //
+        // Basically, a newline is one of:
+        //
+        //  "\n"
+        //  "\r"
+        //  "\r\n"
+        //  "\n\r"
+        //
+        // We always look for the longest match possible.
+        //
+        static void handleNewLineInner(Lexer* lexer, int c)
+        {
+            assert(c == '\n' || c == '\r');
+
+            int d = peekRaw(lexer);
+            if( (c ^ d) == ('\n' ^ '\r') )
+            {
+                advanceRaw(lexer);
+            }
+
+            lexer->loc.Line++;
+            lexer->loc.Col = 1;
+        }
+
+        // Look ahead one code point, dealing with complications like
+        // escaped newlines.
+        static int peek(Lexer* lexer)
+        {
+            // Look at the next raw byte, and decide what to do
+            int c = peekRaw(lexer);
+
+            if(c == '\\')
+            {
+                // We might have a backslash-escaped newline.
+                // Look at the next byte (if any) to see.
+                //
+                // Note(tfoley): We are assuming a null-terminated input here,
+                // so that we can safely look at the next byte without issue.
+                int d = lexer->cursor[1];
+                switch (d)
+                {
+                case '\r': case '\n':
+                    {
+                        // The newline was escaped, so return the code point after *that*
+
+                        int e = lexer->cursor[2];
+                        if ((d ^ e) == ('\r' ^ '\n'))
+                            return lexer->cursor[3];
+                        return e;
+                    }
+
+                default:
+                    break;
+                }
+            }
+            // TODO: handle UTF-8 encoding for non-ASCII code points here
+
+            // Default case is to just hand along the byte we read as an ASCII code point.
+            return c;
+        }
+
+        // Get the next code point from the input, and advance the cursor.
+        static int advance(Lexer* lexer)
+        {
+            // We are going to loop, but only as a way of handling
+            // escaped line endings.
+            for (;;)
+            {
+                // If we are at the end of the input, then the task is easy.
+                if (lexer->cursor == lexer->end)
+                    return kEOF;
+
+                // Look at the next raw byte, and decide what to do
+                int c = *lexer->cursor++;
+
+                if (c == '\\')
+                {
+                    // We might have a backslash-escaped newline.
+                    // Look at the next byte (if any) to see.
+                    //
+                    // Note(tfoley): We are assuming a null-terminated input here,
+                    // so that we can safely look at the next byte without issue.
+                    int d = *lexer->cursor;
+                    switch (d)
+                    {
+                    case '\r': case '\n':
+                        // handle the end-of-line for our source location tracking
+                        lexer->cursor++;
+                        handleNewLineInner(lexer, d);
+
+                        // Now try again, looking at the character after the
+                        // escaped nmewline.
+                        continue;
+
+                    default:
+                        break;
+                    }
+                }
+
+                // TODO: Need to handle non-ASCII code points.
+
+                // Default case is to advance by one location
+                // and return the raw byte we saw.
+
+                lexer->loc.Col++;
+                lexer->loc.Pos++;
+
+                return c;
+            }
         }
 
         static void handleNewLine(Lexer* lexer)
         {
             int c = advance(lexer);
-            assert(c == '\n' || c == '\r');
-
-            int d = peek(lexer);
-            if( (c ^ d) == ('\n' ^ '\r') )
-            {
-                advance(lexer);
-            }
-
-            lexer->loc.Line++;
-            lexer->loc.Col = 1;
+            handleNewLineInner(lexer, c);
         }
 
         static void lexLineComment(Lexer* lexer)

--- a/Framework/Externals/slang/source/slang/slang-stdlib.cpp
+++ b/Framework/Externals/slang/source/slang/slang-stdlib.cpp
@@ -8,16 +8,16 @@
 #define LINE_STRING STRINGIZE(__LINE__)
 
 enum { kLibIncludeStringLine = __LINE__+1 };
-const char * LibIncludeStringChunks[] = { R"(
+const char * LibIncludeStringChunks[] = { R"=(
 
 typedef uint UINT;
 
-__generic<T> __intrinsic(Assign) T operator=(out T left, T right);
+__generic<T> __intrinsic_op(Assign) T operator=(out T left, T right);
 
-__generic<T,U> __intrinsic(Sequence) U operator,(T left, U right);
+__generic<T,U> __intrinsic_op(Sequence) U operator,(T left, U right);
 
-__generic<T> __intrinsic(Select) T operator?:(bool condition, T ifTrue, T ifFalse);
-__generic<T, let N : int> __intrinsic(Select) vector<T,N> operator?:(vector<bool,N> condition, vector<T,N> ifTrue, vector<T,N> ifFalse);
+__generic<T> __intrinsic_op(Select) T operator?:(bool condition, T ifTrue, T ifFalse);
+__generic<T, let N : int> __intrinsic_op(Select) vector<T,N> operator?:(vector<bool,N> condition, vector<T,N> ifTrue, vector<T,N> ifFalse);
 
 __generic<T> __magic_type(HLSLAppendStructuredBufferType) struct AppendStructuredBuffer
 {
@@ -234,7 +234,7 @@ __generic<T> __magic_type(HLSLPointStreamType) struct PointStream {};
 __generic<T> __magic_type(HLSLLineStreamType) struct LineStream {};
 __generic<T> __magic_type(HLSLLineStreamType) struct TriangleStream {};
 
-)", R"(
+)=", R"=(
 
 // Note(tfoley): Trying to systematically add all the HLSL builtins
 
@@ -503,7 +503,7 @@ __generic<T : __BuiltinFloatingPointType> __intrinsic T fwidth(T x);
 __generic<T : __BuiltinFloatingPointType, let N : int> __intrinsic vector<T,N> fwidth(vector<T,N> x);
 __generic<T : __BuiltinFloatingPointType, let N : int, let M : int> __intrinsic matrix<T,N,M> fwidth(matrix<T,N,M> x);
 
-)", R"(
+)=", R"=(
 
 // Get number of samples in render target
 __intrinsic uint GetRenderTargetSampleCount();
@@ -615,27 +615,27 @@ __intrinsic uint4 msad4(uint reference, uint2 source, uint4 accum);
 // General inner products
 
 // scalar-scalar
-__generic<T : __BuiltinArithmeticType> __intrinsic(Mul_Scalar_Scalar) T mul(T x, T y);
+__generic<T : __BuiltinArithmeticType> __intrinsic_op(Mul_Scalar_Scalar) T mul(T x, T y);
 
 // scalar-vector and vector-scalar
-__generic<T : __BuiltinArithmeticType, let N : int> __intrinsic(Mul_Vector_Scalar) vector<T,N> mul(vector<T,N> x, T y);
-__generic<T : __BuiltinArithmeticType, let N : int> __intrinsic(Mul_Scalar_Vector) vector<T,N> mul(T x, vector<T,N> y);
+__generic<T : __BuiltinArithmeticType, let N : int> __intrinsic_op(Mul_Vector_Scalar) vector<T,N> mul(vector<T,N> x, T y);
+__generic<T : __BuiltinArithmeticType, let N : int> __intrinsic_op(Mul_Scalar_Vector) vector<T,N> mul(T x, vector<T,N> y);
 
 // scalar-matrix and matrix-scalar
-__generic<T : __BuiltinArithmeticType, let N : int, let M :int> __intrinsic(Mul_Matrix_Scalar) matrix<T,N,M> mul(matrix<T,N,M> x, T y);
-__generic<T : __BuiltinArithmeticType, let N : int, let M :int> __intrinsic(Mul_Scalar_Matrix) matrix<T,N,M> mul(T x, matrix<T,N,M> y);
+__generic<T : __BuiltinArithmeticType, let N : int, let M :int> __intrinsic_op(Mul_Matrix_Scalar) matrix<T,N,M> mul(matrix<T,N,M> x, T y);
+__generic<T : __BuiltinArithmeticType, let N : int, let M :int> __intrinsic_op(Mul_Scalar_Matrix) matrix<T,N,M> mul(T x, matrix<T,N,M> y);
 
 // vector-vector (dot product)
-__generic<T : __BuiltinArithmeticType, let N : int> __intrinsic(InnerProduct_Vector_Vector) T mul(vector<T,N> x, vector<T,N> y);
+__generic<T : __BuiltinArithmeticType, let N : int> __intrinsic_op(InnerProduct_Vector_Vector) T mul(vector<T,N> x, vector<T,N> y);
 
 // vector-matrix
-__generic<T : __BuiltinArithmeticType, let N : int, let M : int> __intrinsic(InnerProduct_Vector_Matrix) vector<T,M> mul(vector<T,N> x, matrix<T,N,M> y);
+__generic<T : __BuiltinArithmeticType, let N : int, let M : int> __intrinsic_op(InnerProduct_Vector_Matrix) vector<T,M> mul(vector<T,N> x, matrix<T,N,M> y);
 
 // matrix-vector
-__generic<T : __BuiltinArithmeticType, let N : int, let M : int> __intrinsic(InnerProduct_Matrix_Vector) vector<T,N> mul(matrix<T,N,M> x, vector<T,M> y);
+__generic<T : __BuiltinArithmeticType, let N : int, let M : int> __intrinsic_op(InnerProduct_Matrix_Vector) vector<T,N> mul(matrix<T,N,M> x, vector<T,M> y);
 
 // matrix-matrix
-__generic<T : __BuiltinArithmeticType, let R : int, let N : int, let C : int> __intrinsic(InnerProduct_Matrix_Matrix) matrix<T,R,C> mul(matrix<T,R,N> x, matrix<T,N,C> y);
+__generic<T : __BuiltinArithmeticType, let R : int, let N : int, let C : int> __intrinsic_op(InnerProduct_Matrix_Matrix) matrix<T,R,C> mul(matrix<T,R,N> x, matrix<T,N,C> y);
 
 // noise (deprecated)
 __intrinsic float noise(float x);
@@ -759,9 +759,17 @@ __generic<T : __BuiltinFloatingPointType, let N : int> __intrinsic vector<T,N> r
 __generic<T : __BuiltinFloatingPointType, let N : int, let M : int> __intrinsic matrix<T,N,M> rsqrt(matrix<T,N,M> x);
 
 // Clamp value to [0,1] range
-__generic<T : __BuiltinFloatingPointType> __intrinsic T saturate(T x);
-__generic<T : __BuiltinFloatingPointType, let N : int> __intrinsic vector<T,N> saturate(vector<T,N> x);
-__generic<T : __BuiltinFloatingPointType, let N : int, let M : int> __intrinsic matrix<T,N,M> saturate(matrix<T,N,M> x);
+__generic<T : __BuiltinFloatingPointType>
+__intrinsic(glsl, "clamp($0, 0, 1)") __intrinsic
+T saturate(T x);
+
+__generic<T : __BuiltinFloatingPointType, let N : int>
+__intrinsic(glsl, "clamp($0, 0, 1)") __intrinsic
+vector<T,N> saturate(vector<T,N> x);
+
+__generic<T : __BuiltinFloatingPointType, let N : int, let M : int>
+__intrinsic(glsl, "clamp($0, 0, 1)") __intrinsic
+matrix<T,N,M> saturate(matrix<T,N,M> x);
 
 
 // Extract sign of value
@@ -769,7 +777,7 @@ __generic<T : __BuiltinSignedArithmeticType> __intrinsic int sign(T x);
 __generic<T : __BuiltinSignedArithmeticType, let N : int> __intrinsic vector<int,N> sign(vector<T,N> x);
 __generic<T : __BuiltinSignedArithmeticType, let N : int, let M : int> __intrinsic matrix<int,N,M> sign(matrix<T,N,M> x);
 
-)", R"(
+)=", R"=(
 
 
 // Sine
@@ -853,7 +861,7 @@ __generic<T : __BuiltinFloatingPointType, let N : int> __intrinsic vector<T,N> t
 __generic<T : __BuiltinFloatingPointType, let N : int, let M : int> __intrinsic matrix<T,N,M> trunc(matrix<T,N,M> x);
 
 
-)", R"(
+)=", R"=(
 
 // Shader model 6.0 stuff
 
@@ -930,13 +938,13 @@ __generic<T : __BuiltinType, let N : int> __intrinsic vector<T,N> WaveReadLaneAt
 __generic<T : __BuiltinType, let N : int, let M : int> __intrinsic matrix<T,N,M> WaveReadLaneAt(matrix<T,N,M> expr, int laneIndex);
 
 
-)", R"(
+)=", R"=(
 
 // `typedef`s to help with the fact that HLSL has been sorta-kinda case insensitive at various points
 typedef Texture2D texture2D;
 
 #line default
-)" };
+)=" };
 
 
 using namespace CoreLib::Basic;
@@ -1522,19 +1530,6 @@ namespace Slang
             sb << "__intrinsic mat4 operator * (mat4, mat4);\n";
 #endif
 
-#if 0
-            sb << "__intrinsic(And) bool operator && (bool, bool);\n";
-            sb << "__intrinsic(Or) bool operator || (bool, bool);\n";
-
-            for (auto type : intTypes)
-            {
-                sb << "__intrinsic(And) bool operator && (bool, " << type << ");\n";
-                sb << "__intrinsic(Or) bool operator || (bool, " << type << ");\n";
-                sb << "__intrinsic(And) bool operator && (" << type << ", bool);\n";
-                sb << "__intrinsic(Or) bool operator || (" << type << ", bool);\n";
-            }
-#endif
-
             for (auto op : unaryOps)
             {
                 for (auto type : kBaseTypes)
@@ -1547,17 +1542,17 @@ namespace Slang
 
                     // scalar version
                     sb << fixity;
-                    sb << "__intrinsic(" << int(op.opCode) << ") " << type.name << " operator" << op.opName << "(" << qual << type.name << " value);\n";
+                    sb << "__intrinsic_op(" << int(op.opCode) << ") " << type.name << " operator" << op.opName << "(" << qual << type.name << " value);\n";
 
                     // vector version
                     sb << "__generic<let N : int> ";
                     sb << fixity;
-                    sb << "__intrinsic(" << int(op.opCode) << ") vector<" << type.name << ",N> operator" << op.opName << "(" << qual << "vector<" << type.name << ",N> value);\n";
+                    sb << "__intrinsic_op(" << int(op.opCode) << ") vector<" << type.name << ",N> operator" << op.opName << "(" << qual << "vector<" << type.name << ",N> value);\n";
 
                     // matrix version
                     sb << "__generic<let N : int, let M : int> ";
                     sb << fixity;
-                    sb << "__intrinsic(" << int(op.opCode) << ") matrix<" << type.name << ",N,M> operator" << op.opName << "(" << qual << "matrix<" << type.name << ",N,M> value);\n";
+                    sb << "__intrinsic_op(" << int(op.opCode) << ") matrix<" << type.name << ",N,M> operator" << op.opName << "(" << qual << "matrix<" << type.name << ",N,M> value);\n";
                 }
             }
 
@@ -1580,15 +1575,15 @@ namespace Slang
                     // TODO: handle `SHIFT`
 
                     // scalar version
-                    sb << "__intrinsic(" << int(op.opCode) << ") " << resultType << " operator" << op.opName << "(" << leftQual << leftType << " left, " << rightType << " right);\n";
+                    sb << "__intrinsic_op(" << int(op.opCode) << ") " << resultType << " operator" << op.opName << "(" << leftQual << leftType << " left, " << rightType << " right);\n";
 
                     // vector version
                     sb << "__generic<let N : int> ";
-                    sb << "__intrinsic(" << int(op.opCode) << ") vector<" << resultType << ",N> operator" << op.opName << "(" << leftQual << "vector<" << leftType << ",N> left, vector<" << rightType << ",N> right);\n";
+                    sb << "__intrinsic_op(" << int(op.opCode) << ") vector<" << resultType << ",N> operator" << op.opName << "(" << leftQual << "vector<" << leftType << ",N> left, vector<" << rightType << ",N> right);\n";
 
                     // matrix version
                     sb << "__generic<let N : int, let M : int> ";
-                    sb << "__intrinsic(" << int(op.opCode) << ") matrix<" << resultType << ",N,M> operator" << op.opName << "(" << leftQual << "matrix<" << leftType << ",N,M> left, matrix<" << rightType << ",N,M> right);\n";
+                    sb << "__intrinsic_op(" << int(op.opCode) << ") matrix<" << resultType << ",N,M> operator" << op.opName << "(" << leftQual << "matrix<" << leftType << ",N,M> left, matrix<" << rightType << ",N,M> right);\n";
                 }
             }
 

--- a/Framework/Externals/slang/source/slang/syntax-visitors.h
+++ b/Framework/Externals/slang/source/slang/syntax-visitors.h
@@ -10,11 +10,27 @@ namespace Slang
     namespace Compiler
     {
         class CompileOptions;
+        struct CompileRequest;
         class ShaderCompiler;
         class ShaderLinkInfo;
         class ShaderSymbol;
 
-        SyntaxVisitor * CreateSemanticsVisitor(DiagnosticSink * err, CompileOptions const& options);
+        SyntaxVisitor* CreateSemanticsVisitor(
+            DiagnosticSink*         err,
+            CompileOptions const&   options,
+            CompileRequest*         request);
+
+        // Look for a module that matches the given name:
+        // either one we've loaded already, or one we
+        // can find vai the search paths available to us.
+        //
+        // Needed by import declaration checking.
+        //
+        // TODO: need a better location to declare this.
+        RefPtr<ProgramSyntaxNode> findOrImportModule(
+            CompileRequest*     request,
+            String const&       name,
+            CodePosition const& loc);
     }
 }
 

--- a/Framework/Externals/slang/source/slang/syntax.cpp
+++ b/Framework/Externals/slang/source/slang/syntax.cpp
@@ -193,11 +193,12 @@ namespace Slang
             return visitor->VisitParameter(this);
         }
 
-        // UsingFileDecl
+        // ImportDecl
 
-        RefPtr<SyntaxNode> UsingFileDecl::Accept(SyntaxVisitor * visitor)
+        RefPtr<SyntaxNode> ImportDecl::Accept(SyntaxVisitor * visitor)
         {
-            return visitor->VisitUsingFileDecl(this);
+            visitor->visitImportDecl(this);
+            return this;
         }
 
         //

--- a/Framework/Source/API/ProgramReflection.cpp
+++ b/Framework/Source/API/ProgramReflection.cpp
@@ -770,6 +770,13 @@ namespace Falcor
             // TODO: If we ever start using arrays of constant buffers,
             // we'd probably want to handle them here too...
 
+        // Explicitly skip constant buffers at this step, because
+        // otherwise the test below for resources would catch then
+        // when using Vulkan (because constant buffers use the same
+        // binding space as texture/sampler parameters).
+        case TypeReflection::Kind::ConstantBuffer:
+            break;
+
         default:
             // This might be a resource, or an array of resources.
             // To find out, let's ask what category of resource
@@ -779,6 +786,7 @@ namespace Falcor
             case ParameterCategory::ShaderResource:
             case ParameterCategory::UnorderedAccess:
             case ParameterCategory::SamplerState:
+            case ParameterCategory::DescriptorTableSlot:
                 // This is a resource, or an array of them (or an array of arrays ...)
                 reflectResource(
                     pContext,


### PR DESCRIPTION
This comprises two changes:

1. Update Falcor to use a newer version of the Slang code

2. Make some small fixes to the Falcor reflection code to handle the way that Vulkan shader parameters are exposed.

With this change I've confirmed that basic shader parameters - textures, samplers, and constant buffers - are properly showing up in the Falcor reflection data structures when compiling a Vulkan shader.