### PR TITLE
Update Slang to fix `InputPatch` bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,18 @@ FalcorTest.VC.db
 FalcorTest/TestResults/*
 Falcor.VC.VC.opendb
 Framework/Externals/NVAPI/
-Framework/Externals/slang/*
-!Framework/Externals/slang/source/**/*.h
-!Framework/Externals/slang/source/**/*.cpp
 .vs/*
 Test/OutputTestingHtml.pyc
 Test/TestingUtil.pyc
 Test/RunAllTests.pyc
+
+# A bit of a song and dance to ignore all the files
+# in the Slang codebase except for the ones we need.
+Framework/Externals/slang/*
+!Framework/Externals/slang/source/
+Framework/Externals/slang/source/**/*.vcxproj
+Framework/Externals/slang/source/**/*.filters
+Framework/Externals/slang/source/**/*.natvis
+!Framework/Externals/slang/source/**/*.cpp
+!Framework/Externals/slang/source/**/*.cpp
+!Framework/Externals/slang/source/**/*.h

--- a/Framework/Externals/slang/slang.h
+++ b/Framework/Externals/slang/slang.h
@@ -194,8 +194,8 @@ extern "C"
         void const*             userData);
 
     /*!
-    @brief Add a path in which source files are being search. When the programmer specifies @code using <file_name> @endcode in code, the compiler searches the file
-    in all search pathes in order.
+    @brief Add a path to use when searching for referenced files.
+    This will be used for both `#include` directives and also for explicit `__import` declarations.
     @param ctx The compilation context.
     @param searchDir The additional search directory.
     */
@@ -203,6 +203,16 @@ extern "C"
         SlangCompileRequest*    request,
         const char*             searchDir);
 
+    /*!
+    @brief Add a path to use when searching for referenced files, that automatically treats `#include` as `__import`
+    This behaves just like `spAddSearchPath()` except that any `#include` file found through this path
+    will be treated as if it was referenced with `__import`.
+    @param ctx The compilation context.
+    @param searchDir The additional search directory.
+    */
+    SLANG_API void spAddAutoImportPath(
+        SlangCompileRequest*    request,
+        const char*             searchDir);
     /*!
     @brief Add a macro definition to be used during preprocessing.
     @param key The name of the macro to define.
@@ -213,6 +223,13 @@ extern "C"
         const char*             key,
         const char*             value);
 
+    /*!
+    @brief Set options using arguments as if specified via command line.
+    */
+    SLANG_API int spProcessCommandLineArguments(
+        SlangCompileRequest*    request,
+        char const* const*      args,
+        int                     argCount);
 
     /** Add a distinct translation unit to the compilation request
 
@@ -890,6 +907,7 @@ namespace slang
 #include "source/slang/diagnostics.cpp"
 #include "source/slang/emit.cpp"
 #include "source/slang/lexer.cpp"
+#include "source/slang/options.cpp"
 #include "source/slang/parameter-binding.cpp"
 #include "source/slang/parser.cpp"
 #include "source/slang/preprocessor.cpp"

--- a/Framework/Externals/slang/source/core/slang-io.h
+++ b/Framework/Externals/slang/source/core/slang-io.h
@@ -20,11 +20,8 @@ namespace Slang
 	class Path
 	{
 	public:
-#ifdef _WIN32
-		static const char PathDelimiter = '\\';
-#else
 		static const char PathDelimiter = '/';
-#endif
+
 		static String TruncateExt(const String & path);
 		static String ReplaceExt(const String & path, const char * newExt);
 		static String GetFileName(const String & path);

--- a/Framework/Externals/slang/source/core/slang-string.h
+++ b/Framework/Externals/slang/source/core/slang-string.h
@@ -141,6 +141,16 @@ namespace Slang
 				memcpy(buffer.Ptr(), str, length + 1);
 			}
 		}
+        String(const char* textBegin, char const* textEnd)
+		{
+			if (textBegin != textEnd)
+			{
+				length = (int)(textEnd - textBegin);
+				buffer = new char[length + 1];
+				memcpy(buffer.Ptr(), textBegin, length + 1);
+                buffer.Ptr()[length] = 0;
+			}
+		}
 		String(char chr)
 		{
 			if (chr)

--- a/Framework/Externals/slang/source/slang/check.cpp
+++ b/Framework/Externals/slang/source/slang/check.cpp
@@ -47,6 +47,7 @@ namespace Slang
         ProgramSyntaxNode * program = nullptr;
         FunctionSyntaxNode * function = nullptr;
         CompileOptions const* options = nullptr;
+        TranslationUnitOptions const* translationUnitOptions = nullptr;
         CompileRequest* request = nullptr;
 
         // lexical outer statements
@@ -55,14 +56,17 @@ namespace Slang
         SemanticsVisitor(
             DiagnosticSink * pErr,
             CompileOptions const& options,
+            TranslationUnitOptions const& translationUnitOptions,
             CompileRequest* request)
             : SyntaxVisitor(pErr)
             , options(&options)
+            , translationUnitOptions(&translationUnitOptions)
             , request(request)
         {
         }
 
         CompileOptions const& getOptions() { return *options; }
+        TranslationUnitOptions const& getTranslationUnitOptions() { return *translationUnitOptions; }
 
     public:
         // Translate Types
@@ -965,7 +969,7 @@ namespace Slang
             // expressions without a type, and we need to ignore them.
             if( !fromExpr->Type.type )
             {
-                if(getOptions().flags & SLANG_COMPILE_FLAG_NO_CHECKING )
+                if(getTranslationUnitOptions().compileFlags & SLANG_COMPILE_FLAG_NO_CHECKING )
                     return fromExpr;
             }
 
@@ -977,7 +981,7 @@ namespace Slang
                 fromExpr.Ptr(),
                 nullptr))
             {
-                if(!(getOptions().flags & SLANG_COMPILE_FLAG_NO_CHECKING))
+                if(!(getTranslationUnitOptions().compileFlags & SLANG_COMPILE_FLAG_NO_CHECKING))
                 {
                     getSink()->diagnose(fromExpr->Position, Diagnostics::typeMismatch, toType, fromExpr->Type);
                 }
@@ -4963,11 +4967,12 @@ namespace Slang
     };
 
     SyntaxVisitor* CreateSemanticsVisitor(
-        DiagnosticSink*         err,
-        CompileOptions const&   options,
-        CompileRequest*         request)
+        DiagnosticSink*                 err,
+        CompileOptions const&           options,
+        TranslationUnitOptions const&   translationUnitOptions,
+        CompileRequest*                 request)
     {
-        return new SemanticsVisitor(err, options, request);
+        return new SemanticsVisitor(err, options, translationUnitOptions, request);
     }
 
     //

--- a/Framework/Externals/slang/source/slang/compiler.h
+++ b/Framework/Externals/slang/source/slang/compiler.h
@@ -89,6 +89,29 @@ namespace Slang
         // Preprocessor definitions to use for this translation unit only
         // (whereas the ones on `CompileOptions` will be shared)
         Dictionary<String, String> preprocessorDefinitions;
+
+        // Compile flags for this translation unit
+        SlangCompileFlags compileFlags = 0;
+    };
+
+
+    struct SearchDirectory
+    {
+        enum Kind
+        {
+            Default,
+            AutoImport,
+        };
+
+        SearchDirectory() = default;
+        SearchDirectory(SearchDirectory const& other) = default;
+        SearchDirectory(String const& path, Kind kind)
+            : path(path)
+            , kind(kind)
+        {}
+
+        String  path;
+        Kind    kind;
     };
 
     class CompileOptions
@@ -98,7 +121,7 @@ namespace Slang
         CodeGenTarget Target = CodeGenTarget::Unknown;
 
         // Directories to search for `#include` files or `import`ed modules
-        List<String> SearchDirectories;
+        List<SearchDirectory> searchDirectories;
 
         // Definitions to provide during preprocessing
         Dictionary<String, String> preprocessorDefinitions;
@@ -112,8 +135,8 @@ namespace Slang
         // Should we just pass the input to another compiler?
         PassThroughMode passThrough = PassThroughMode::None;
 
-        // Flags supplied through the API
-        SlangCompileFlags flags = 0;
+        // Compile flags to be shared by all translation units
+        SlangCompileFlags compileFlags = 0;
     };
 
     // This is the representation of a given translation unit

--- a/Framework/Externals/slang/source/slang/lexer.cpp
+++ b/Framework/Externals/slang/source/slang/lexer.cpp
@@ -1052,8 +1052,39 @@ namespace Slang
             // Note(tfoley): `StringBuilder::Append()` seems to crash when appending zero bytes
             if(textEnd != textBegin)
             {
+                // HACK(tfoley): "scrubbing" token value here to remove escaped newlines...
+                //
+                // TODO: Only perform this work if we encountered an escaped newline
+                // while lexing this token (e.g., keep a flag on the lexer), or
+                // do it on-demand when the actual value of the token is needed.
+
                 StringBuilder valueBuilder;
-                valueBuilder.Append(textBegin, int(textEnd - textBegin));
+                auto tt = textBegin;
+                while(tt != textEnd)
+                {
+                    char c = *tt++;
+                    if(c == '\\')
+                    {
+                        char d = *tt;
+                        switch(d)
+                        {
+                        case '\r': case '\n':
+                            {
+                                tt++;
+                                char e = *tt;
+                                if((d ^ e) == ('\r' ^ '\n'))
+                                {
+                                    tt++;
+                                }
+                            }
+                            continue;
+
+                        default:
+                            break;
+                        }
+                    }
+                    valueBuilder.Append(c);
+                }
                 token.Content = valueBuilder.ProduceString();
             }
 

--- a/Framework/Externals/slang/source/slang/options.cpp
+++ b/Framework/Externals/slang/source/slang/options.cpp
@@ -1,0 +1,566 @@
+// options.cpp
+
+// Implementation of options parsing for `slangc` command line,
+// and also for API interface that takes command-line argument strings.
+
+#include "../../slang.h"
+
+#include "profile.h"
+
+#include <assert.h>
+
+namespace Slang {
+
+char const* tryReadCommandLineArgumentRaw(char const* option, char const* const**ioCursor, char const* const*end)
+{
+    char const* const*& cursor = *ioCursor;
+    if (cursor == end)
+    {
+        fprintf(stderr, "expected an argument for command-line option '%s'", option);
+        exit(1);
+    }
+    else
+    {
+        return *cursor++;
+    }
+}
+
+String tryReadCommandLineArgument(char const* option, char const* const**ioCursor, char const* const*end)
+{
+    return String(tryReadCommandLineArgumentRaw(option, ioCursor, end));
+}
+
+
+
+
+
+struct OptionsParser
+{
+    SlangSession*           session = nullptr;
+    SlangCompileRequest*    compileRequest = nullptr;
+
+    struct RawTranslationUnit
+    {
+        SlangSourceLanguage sourceLanguage;
+        SlangProfileID      implicitProfile;
+        int                 translationUnitIndex;
+    };
+
+    // Collect translation units so that we can futz with them later
+    List<RawTranslationUnit> rawTranslationUnits;
+
+    struct RawEntryPoint
+    {
+        String          name;
+        SlangProfileID  profileID = SLANG_PROFILE_UNKNOWN;
+        int             translationUnitIndex = -1;
+    };
+
+    // Collect entry point names, so that we can associate them
+    // with entry points later...
+    List<RawEntryPoint> rawEntryPoints;
+
+    // The number of input files that have been specified
+    int inputPathCount = 0;
+
+    // If we already have a translation unit for Slang code, then this will give its index.
+    // If not, it will be `-1`.
+    int slangTranslationUnit = -1;
+
+    int translationUnitCount = 0;
+    int currentTranslationUnitIndex = -1;
+
+    SlangProfileID currentProfileID = SLANG_PROFILE_UNKNOWN;
+
+    SlangCompileFlags flags = 0;
+
+    int addTranslationUnit(
+        SlangSourceLanguage language,
+        SlangProfileID      implicitProfile = SLANG_PROFILE_UNKNOWN)
+    {
+        auto translationUnitIndex = spAddTranslationUnit(compileRequest, language, nullptr);
+
+        assert(translationUnitIndex == rawTranslationUnits.Count());
+
+        RawTranslationUnit rawTranslationUnit;
+        rawTranslationUnit.sourceLanguage = language;
+        rawTranslationUnit.implicitProfile = implicitProfile;
+        rawTranslationUnit.translationUnitIndex = translationUnitIndex;
+
+        rawTranslationUnits.Add(rawTranslationUnit);
+
+        return translationUnitIndex;
+    }
+
+    void addInputSlangPath(
+        String const& path)
+    {
+        // All of the input .slang files will be grouped into a single logical translation unit,
+        // which we create lazily when the first .slang file is encountered.
+        if( slangTranslationUnit == -1 )
+        {
+            translationUnitCount++;
+            slangTranslationUnit = addTranslationUnit(SLANG_SOURCE_LANGUAGE_SLANG);
+        }
+
+        spAddTranslationUnitSourceFile(
+            compileRequest,
+            slangTranslationUnit,
+            path.begin());
+
+        // Set the translation unit to be used by subsequent entry points
+        currentTranslationUnitIndex = slangTranslationUnit;
+    }
+
+    void addInputForeignShaderPath(
+        String const&           path,
+        SlangSourceLanguage     language,
+        SlangProfileID          implicitProfile = SLANG_PROFILE_UNKNOWN)
+    {
+        translationUnitCount++;
+        currentTranslationUnitIndex = addTranslationUnit(language, implicitProfile);
+
+        spAddTranslationUnitSourceFile(
+            compileRequest,
+            currentTranslationUnitIndex,
+            path.begin());
+    }
+
+    void addInputPath(
+        char const*  inPath)
+    {
+        inputPathCount++;
+
+        // look at the extension on the file name to determine
+        // how we should handle it.
+        String path = String(inPath);
+
+        if( path.EndsWith(".slang") )
+        {
+            // Plain old slang code
+            addInputSlangPath(path);
+        }
+#define CASE(EXT, LANG) \
+        else if(path.EndsWith(EXT)) do { addInputForeignShaderPath(path, SLANG_SOURCE_LANGUAGE_##LANG); } while(0)
+
+        CASE(".hlsl", HLSL);
+        CASE(".fx",   HLSL);
+
+        CASE(".glsl", GLSL);
+#undef CASE
+
+#define CASE(EXT, LANG, PROFILE) \
+        else if(path.EndsWith(EXT)) do { addInputForeignShaderPath(path, SLANG_SOURCE_LANGUAGE_##LANG, SlangProfileID(Slang::Profile::PROFILE)); } while(0)
+        // TODO: need a way to pass along stage/profile and entry-point info for these cases...
+        CASE(".vert", GLSL, GLSL_Vertex);
+        CASE(".frag", GLSL, GLSL_Fragment);
+        CASE(".geom", GLSL, GLSL_Geometry);
+        CASE(".tesc", GLSL, GLSL_TessControl);
+        CASE(".tese", GLSL, GLSL_TessEval);
+        CASE(".comp", GLSL, GLSL_Compute);
+
+#undef CASE
+
+        else
+        {
+            fprintf(stderr, "error: can't deduce language for input file '%s'\n", inPath);
+            exit(1);
+        }
+    }
+
+    int parse(
+        int             argc,
+        char const* const*  argv)
+    {
+        char const* const* argCursor = &argv[0];
+        char const* const* argEnd = &argv[argc];
+        while (argCursor != argEnd)
+        {
+            char const* arg = *argCursor++;
+            if (arg[0] == '-')
+            {
+                String argStr = String(arg);
+
+                // The argument looks like an option, so try to parse it.
+//                if (argStr == "-outdir")
+//                    outputDir = tryReadCommandLineArgument(arg, &argCursor, argEnd);
+//                if (argStr == "-out")
+//                    options.outputName = tryReadCommandLineArgument(arg, &argCursor, argEnd);
+//                else if (argStr == "-symbo")
+//                    options.SymbolToCompile = tryReadCommandLineArgument(arg, &argCursor, argEnd);
+                //else
+                if (argStr == "-no-checking")
+                    flags |= SLANG_COMPILE_FLAG_NO_CHECKING;
+                else if (argStr == "-backend" || argStr == "-target")
+                {
+                    String name = tryReadCommandLineArgument(arg, &argCursor, argEnd);
+                    SlangCompileTarget target = SLANG_TARGET_UNKNOWN;
+
+                    if (name == "glsl")
+                    {
+                        target = SLANG_GLSL;
+                    }
+                    else if (name == "glsl_vk")
+                    {
+                        target = SLANG_GLSL_VULKAN;
+                    }
+//                    else if (name == "glsl_vk_onedesc")
+//                    {
+//                        options.Target = CodeGenTarget::GLSL_Vulkan_OneDesc;
+//                    }
+                    else if (name == "hlsl")
+                    {
+                        target = SLANG_HLSL;
+                    }
+                    else if (name == "spriv")
+                    {
+                        target = SLANG_SPIRV;
+                    }
+                    else if (name == "dxbc")
+                    {
+                        target = SLANG_DXBC;
+                    }
+                    else if (name == "dxbc-assembly")
+                    {
+                        target = SLANG_DXBC_ASM;
+                    }
+                #define CASE(NAME, TARGET)  \
+                    else if(name == #NAME) do { target = SLANG_##TARGET; } while(0)
+
+                    CASE(spirv, SPIRV);
+                    CASE(spirv-assembly, SPIRV_ASM);
+
+                #undef CASE
+
+                    else if (name == "reflection-json")
+                    {
+                        target = SLANG_REFLECTION_JSON;
+                    }
+                    else
+                    {
+                        fprintf(stderr, "unknown code generation target '%S'\n", name.ToWString());
+                        exit(1);
+                    }
+
+                    spSetCodeGenTarget(compileRequest, target);
+                }
+                // A "profile" specifies both a specific target stage and a general level
+                // of capability required by the program.
+                else if (argStr == "-profile")
+                {
+                    String name = tryReadCommandLineArgument(arg, &argCursor, argEnd);
+
+                    SlangProfileID profileID = spFindProfile(session, name.begin());
+                    if( profileID == SLANG_PROFILE_UNKNOWN )
+                    {
+                        fprintf(stderr, "unknown profile '%s'\n", name.begin());
+                    }
+                    else
+                    {
+                        currentProfileID = profileID;
+                    }
+                }
+                else if (argStr == "-entry")
+                {
+                    String name = tryReadCommandLineArgument(arg, &argCursor, argEnd);
+
+                    RawEntryPoint entry;
+                    entry.name = name;
+                    entry.translationUnitIndex = currentTranslationUnitIndex;
+
+                    // TODO(tfoley): Allow user to fold a specification of a profile into the entry-point name,
+                    // for the case where they might be compiling multiple entry points in one invocation...
+                    //
+                    // For now, just use the last profile set on the command-line to specify this
+
+                    entry.profileID = currentProfileID;
+
+                    rawEntryPoints.Add(entry);
+                }
+#if 0
+                else if (argStr == "-stage")
+                {
+                    String name = tryReadCommandLineArgument(arg, &argCursor, argEnd);
+                    StageTarget stage = StageTarget::Unknown;
+                    if (name == "vertex") { stage = StageTarget::VertexShader; }
+                    else if (name == "fragment") { stage = StageTarget::FragmentShader; }
+                    else if (name == "hull") { stage = StageTarget::HullShader; }
+                    else if (name == "domain") { stage = StageTarget::DomainShader; }
+                    else if (name == "compute") { stage = StageTarget::ComputeShader; }
+                    else
+                    {
+                        fprintf(stderr, "unknown stage '%S'\n", name.ToWString());
+                    }
+                    options.stage = stage;
+                }
+#endif
+                else if (argStr == "-pass-through")
+                {
+                    String name = tryReadCommandLineArgument(arg, &argCursor, argEnd);
+                    SlangPassThrough passThrough = SLANG_PASS_THROUGH_NONE;
+                    if (name == "fxc") { passThrough = SLANG_PASS_THROUGH_FXC; }
+                    else if (name == "glslang") { passThrough = SLANG_PASS_THROUGH_GLSLANG; }
+                    else
+                    {
+                        fprintf(stderr, "unknown pass-through target '%S'\n", name.ToWString());
+                        exit(1);
+                    }
+
+                    spSetPassThrough(
+                        compileRequest,
+                        passThrough);
+                }
+//                else if (argStr == "-genchoice")
+//                    options.Mode = CompilerMode::GenerateChoice;
+                else if (argStr[1] == 'D')
+                {
+                    // The value to be defined might be part of the same option, as in:
+                    //     -DFOO
+                    // or it might come separately, as in:
+                    //     -D FOO
+                    char const* defineStr = arg + 2;
+                    if (defineStr[0] == 0)
+                    {
+                        // Need to read another argument from the command line
+                        defineStr = tryReadCommandLineArgumentRaw(arg, &argCursor, argEnd);
+                    }
+                    // The string that sets up the define can have an `=` between
+                    // the name to be defined and its value, so we search for one.
+                    char const* eqPos = nullptr;
+                    for(char const* dd = defineStr; *dd; ++dd)
+                    {
+                        if (*dd == '=')
+                        {
+                            eqPos = dd;
+                            break;
+                        }
+                    }
+
+                    // Now set the preprocessor define
+                    //
+                    if (eqPos)
+                    {
+                        // If we found an `=`, we split the string...
+
+                        spAddPreprocessorDefine(
+                            compileRequest,
+                            String(defineStr, eqPos).begin(),
+                            String(eqPos+1).begin());
+                    }
+                    else
+                    {
+                        // If there was no `=`, then just #define it to an empty string
+
+                        spAddPreprocessorDefine(
+                            compileRequest,
+                            String(defineStr).begin(),
+                            "");
+                    }
+                }
+                else if (argStr[1] == 'I')
+                {
+                    // The value to be defined might be part of the same option, as in:
+                    //     -IFOO
+                    // or it might come separately, as in:
+                    //     -I FOO
+                    // (see handling of `-D` above)
+                    char const* includeDirStr = arg + 2;
+                    if (includeDirStr[0] == 0)
+                    {
+                        // Need to read another argument from the command line
+                        includeDirStr = tryReadCommandLineArgumentRaw(arg, &argCursor, argEnd);
+                    }
+
+                    spAddSearchPath(
+                        compileRequest,
+                        String(includeDirStr).begin());
+                }
+                else if (argStr == "-auto-import-dir")
+                {
+                    char const* importDirStr = tryReadCommandLineArgumentRaw(arg, &argCursor, argEnd);
+
+                    spAddAutoImportPath(
+                        compileRequest,
+                        String(importDirStr).begin());
+                }
+                else if (argStr == "--")
+                {
+                    // The `--` option causes us to stop trying to parse options,
+                    // and treat the rest of the command line as input file names:
+                    while (argCursor != argEnd)
+                    {
+                        addInputPath(*argCursor++);
+                    }
+                    break;
+                }
+                else
+                {
+                    fprintf(stderr, "unknown command-line option '%S'\n", argStr.ToWString());
+                    // TODO: print a usage message
+                    exit(1);
+                }
+            }
+            else
+            {
+                addInputPath(arg);
+            }
+        }
+
+        spSetCompileFlags(compileRequest, flags);
+
+        // TODO(tfoley): This kind of validation needs to wait until
+        // after all options have been specified for API usage
+#if 0
+        if (inputPathCount == 0)
+        {
+            fprintf(stderr, "error: no input file specified\n");
+            exit(1);
+        }
+
+        // No point in moving forward if there is nothing to compile
+        if( translationUnitCount == 0 )
+        {
+            fprintf(stderr, "error: no compilation requested\n");
+            exit(1);
+        }
+#endif
+
+        // If the user didn't list any explicit entry points, then we can
+        // try to infer one from the type of input file
+        if(rawEntryPoints.Count() == 0)
+        {
+            for(auto rawTranslationUnit : rawTranslationUnits)
+            {
+                // Dont' add implicit entry points when compiling from Slang files,
+                // since Slang doesn't require entry points to be named on the
+                // command line.
+                if(rawTranslationUnit.sourceLanguage == SLANG_SOURCE_LANGUAGE_SLANG )
+                    continue;
+
+                // Use a default entry point name
+                char const* entryPointName = "main";
+
+                // Try to determine a profile
+                SlangProfileID entryPointProfile = SLANG_PROFILE_UNKNOWN;
+
+                // If a profile was specified on the command line, then we use it
+                if(currentProfileID != SLANG_PROFILE_UNKNOWN)
+                {
+                    entryPointProfile = currentProfileID;
+                }
+                // Otherwise, check if the translation unit implied a profile
+                // (e.g., a `*.vert` file implies the `GLSL_Vertex` profile)
+                else if(rawTranslationUnit.implicitProfile != SLANG_PROFILE_UNKNOWN)
+                {
+                    entryPointProfile = rawTranslationUnit.implicitProfile;
+                }
+
+                RawEntryPoint entry;
+                entry.name = entryPointName;
+                entry.translationUnitIndex = rawTranslationUnit.translationUnitIndex;
+                entry.profileID = entryPointProfile;
+                rawEntryPoints.Add(entry);
+            }
+        }
+
+        // For any entry points that were given without an explicit profile, we can now apply
+        // the profile that was given to them.
+        if( rawEntryPoints.Count() != 0 )
+        {
+            bool anyEntryPointWithoutProfile = false;
+            for( auto& entryPoint : rawEntryPoints )
+            {
+                // Skip entry points that are already associated with a translation unit...
+                if( entryPoint.profileID != SLANG_PROFILE_UNKNOWN )
+                    continue;
+
+                anyEntryPointWithoutProfile = true;
+                break;
+            }
+
+            if( anyEntryPointWithoutProfile )
+            {
+                fprintf(stderr, "error: no profile specified; use the '-profile <profile name>' option");
+                exit(1);
+            }
+            // TODO: issue an error if we have multiple `-profile` options *and*
+            // there are entry points that didn't get a profile.
+            else
+            {
+                for( auto& e : rawEntryPoints )
+                {
+                    if( e.profileID == SLANG_PROFILE_UNKNOWN )
+                    {
+                        e.profileID = currentProfileID;
+                    }
+                }
+            }
+        }
+
+        // Next, we want to make sure that entry points get attached to the appropriate translation
+        // unit that will provide them.
+        {
+            bool anyEntryPointWithoutTranslationUnit = false;
+            for( auto& entryPoint : rawEntryPoints )
+            {
+                // Skip entry points that are already associated with a translation unit...
+                if( entryPoint.translationUnitIndex != -1 )
+                    continue;
+
+                anyEntryPointWithoutTranslationUnit = true;
+                entryPoint.translationUnitIndex = 0;
+            }
+
+            if( anyEntryPointWithoutTranslationUnit && translationUnitCount != 1 )
+            {
+                fprintf(stderr, "error: when using multiple translation units, entry points must be specified after their translation unit file(s)");
+                exit(1);
+            }
+
+            // Now place all those entry points where they belong
+            for( auto& entryPoint : rawEntryPoints )
+            {
+                spAddTranslationUnitEntryPoint(
+                    compileRequest,
+                    entryPoint.translationUnitIndex,
+                    entryPoint.name.begin(),
+                    entryPoint.profileID);
+            }
+        }
+
+#if 0
+        // Automatically derive an output directory based on the first file specified.
+        //
+        // TODO: require manual specification if there are multiple input files, in different directories
+        String fileName = options.translationUnits[0].sourceFilePaths[0];
+        if (outputDir.Length() == 0)
+        {
+            outputDir = Path::GetDirectoryName(fileName);
+        }
+#endif
+
+        return 0;
+    }
+};
+
+
+int parseOptions(
+    SlangCompileRequest*    compileRequest,
+    int                     argc,
+    char const* const*      argv)
+{
+    OptionsParser parser;
+    parser.compileRequest = compileRequest;
+    return parser.parse(argc, argv);
+}
+
+
+} // namespace Slang
+
+SLANG_API int spProcessCommandLineArguments(
+    SlangCompileRequest*    request,
+    char const* const*      args,
+    int                     argCount)
+{
+    return Slang::parseOptions(request, argCount, args);
+}

--- a/Framework/Externals/slang/source/slang/parser.h
+++ b/Framework/Externals/slang/source/slang/parser.h
@@ -9,12 +9,14 @@ namespace Slang
 {
     // Parse a source file into an existing translation unit
     void parseSourceFile(
-        ProgramSyntaxNode*  translationUnitSyntax,
-        CompileOptions&     options,
-        TokenSpan const&    tokens,
-        DiagnosticSink*     sink,
-        String const&       fileName,
-        RefPtr<Scope> const&outerScope);
+        ProgramSyntaxNode*              translationUnitSyntax,
+        CompileOptions const&           options,
+        TranslationUnitOptions const&   translationUnitOptions,
+        TokenSpan const&                tokens,
+        DiagnosticSink*                 sink,
+        String const&                   fileName,
+        RefPtr<Scope> const&            outerScope);
+;
 }
 
 #endif

--- a/Framework/Externals/slang/source/slang/preprocessor.h
+++ b/Framework/Externals/slang/source/slang/preprocessor.h
@@ -7,14 +7,23 @@
 
 namespace Slang {
 
+struct CompileRequest;
 class DiagnosticSink;
 class ProgramSyntaxNode;
+
+enum class IncludeResult
+{
+    Error,
+    NotFound,
+    FoundIncludeFile,
+    FoundAutoImportFile,
+};
 
 // Callback interface for the preprocessor to use when looking
 // for files in `#include` directives.
 struct IncludeHandler
 {
-    virtual bool TryToFindIncludeFile(
+    virtual IncludeResult TryToFindIncludeFile(
         String const& pathToInclude,
         String const& pathIncludedFrom,
         String* outFoundPath,
@@ -23,12 +32,13 @@ struct IncludeHandler
 
 // Take a string of source code and preprocess it into a list of tokens.
 TokenList preprocessSource(
-    String const& source,
-    String const& fileName,
-    DiagnosticSink* sink,
-    IncludeHandler* includeHandler,
-    Dictionary<String, String>  defines,
-    ProgramSyntaxNode*  syntax);
+    String const&               source,
+    String const&               fileName,
+    DiagnosticSink*             sink,
+    IncludeHandler*             includeHandler,
+     Dictionary<String, String> defines,
+    ProgramSyntaxNode*          syntax,
+    CompileRequest*             compileRequest);
 
 } // namespace Slang
 

--- a/Framework/Externals/slang/source/slang/profile.h
+++ b/Framework/Externals/slang/source/slang/profile.h
@@ -13,9 +13,6 @@ namespace Slang
         Slang = SLANG_SOURCE_LANGUAGE_SLANG,
         HLSL = SLANG_SOURCE_LANGUAGE_HLSL,
         GLSL = SLANG_SOURCE_LANGUAGE_GLSL,
-
-        // A separate PACKAGE of Slang code that has been imported
-        ImportedSlangCode,
     };
 
     // TODO(tfoley): This should merge with the above...

--- a/Framework/Externals/slang/source/slang/slang-stdlib.cpp
+++ b/Framework/Externals/slang/source/slang/slang-stdlib.cpp
@@ -78,12 +78,12 @@ __generic<T> __magic_type(HLSLConsumeStructuredBufferType) struct ConsumeStructu
         out uint stride);
 };
 
-__generic<T> __magic_type(HLSLInputPatchType) struct InputPatch
+__generic<T, let N : int> __magic_type(HLSLInputPatchType) struct InputPatch
 {
     __intrinsic __subscript(uint index) -> T;
 };
 
-__generic<T> __magic_type(HLSLOutputPatchType) struct OutputPatch
+__generic<T, let N : int> __magic_type(HLSLOutputPatchType) struct OutputPatch
 {
     __intrinsic __subscript(uint index) -> T { set; }
 };

--- a/Framework/Externals/slang/source/slang/syntax-visitors.h
+++ b/Framework/Externals/slang/source/slang/syntax-visitors.h
@@ -12,11 +12,13 @@ namespace Slang
     class ShaderCompiler;
     class ShaderLinkInfo;
     class ShaderSymbol;
+    class TranslationUnitOptions;
 
     SyntaxVisitor* CreateSemanticsVisitor(
-        DiagnosticSink*         err,
-        CompileOptions const&   options,
-        CompileRequest*         request);
+        DiagnosticSink*                 err,
+        CompileOptions const&           options,
+        TranslationUnitOptions const&   translationUnitOptions,
+        CompileRequest*                 request);
 
     // Look for a module that matches the given name:
     // either one we've loaded already, or one we

--- a/Framework/Externals/slang/source/slang/syntax.cpp
+++ b/Framework/Externals/slang/source/slang/syntax.cpp
@@ -525,6 +525,22 @@ namespace Slang
                 return textureType;
             }
 
+            // TODO: eventually everything should follow this pattern,
+            // and we can drive the dispatch with a table instead
+            // of this ridiculously slow `if` cascade.
+
+        #define CASE(n,T)													\
+            else if(magicMod->name == #n) {									\
+                auto type = new T();										\
+                type->declRef = declRef;									\
+                return type;												\
+            }
+
+            CASE(HLSLInputPatchType, HLSLInputPatchType)
+            CASE(HLSLOutputPatchType, HLSLOutputPatchType)
+
+        #undef CASE
+
             #define CASE(n,T)													\
                 else if(magicMod->name == #n) {									\
                     assert(subst && subst->args.Count() == 1);					\
@@ -550,8 +566,6 @@ namespace Slang
             CASE(HLSLRWStructuredBufferType, HLSLRWStructuredBufferType)
             CASE(HLSLAppendStructuredBufferType, HLSLAppendStructuredBufferType)
             CASE(HLSLConsumeStructuredBufferType, HLSLConsumeStructuredBufferType)
-            CASE(HLSLInputPatchType, HLSLInputPatchType)
-            CASE(HLSLOutputPatchType, HLSLOutputPatchType)
 
             CASE(HLSLPointStreamType, HLSLPointStreamType)
             CASE(HLSLLineStreamType, HLSLPointStreamType)
@@ -1470,4 +1484,17 @@ namespace Slang
         return IntrinsicOp::Unknown;
     }
 
+    //
+
+    // HLSLPatchType
+
+    ExpressionType* HLSLPatchType::getElementType()
+    {
+        return this->declRef.substitutions->args[0].As<ExpressionType>().Ptr();
+    }
+
+    IntVal* HLSLPatchType::getElementCount()
+    {
+        return this->declRef.substitutions->args[1].As<IntVal>().Ptr();
+    }
 }

--- a/Framework/Externals/slang/source/slang/syntax.h
+++ b/Framework/Externals/slang/source/slang/syntax.h
@@ -1044,8 +1044,15 @@ namespace Slang
     class HLSLAppendStructuredBufferType : public BuiltinGenericType {};
     class HLSLConsumeStructuredBufferType : public BuiltinGenericType {};
 
-    class HLSLInputPatchType : public BuiltinGenericType {};
-    class HLSLOutputPatchType : public BuiltinGenericType {};
+    class HLSLPatchType : public DeclRefType
+    {
+    public:
+        ExpressionType* getElementType();
+        IntVal*         getElementCount();
+    };
+
+    class HLSLInputPatchType : public HLSLPatchType {};
+    class HLSLOutputPatchType : public HLSLPatchType {};
 
     // HLSL geometry shader output stream types
 

--- a/Framework/Externals/slang/source/slang/token-defs.h
+++ b/Framework/Externals/slang/source/slang/token-defs.h
@@ -30,6 +30,8 @@ TOKEN(NewLine,          "newline")
 TOKEN(LineComment,      "line comment")
 TOKEN(BlockComment,     "block comment")
 
+TOKEN(AutoImport,       "automatic import directive")
+
 #define PUNCTUATION(id, text) \
     TOKEN(id, "'" text "'")
 

--- a/Framework/Externals/slang/source/slangc/main.cpp
+++ b/Framework/Externals/slang/source/slangc/main.cpp
@@ -8,536 +8,7 @@ using namespace Slang;
 
 #include <assert.h>
 
-// Currently only used for looking up `Profile::` values that aren't
-// exported by the public API
-#include "../slang/profile.h"
-
 // Try to read an argument for a command-line option.
-wchar_t const* tryReadCommandLineArgumentRaw(wchar_t const* option, wchar_t***ioCursor, wchar_t**end)
-{
-    wchar_t**& cursor = *ioCursor;
-    if (cursor == end)
-    {
-        fprintf(stderr, "expected an argument for command-line option '%S'", option);
-        exit(1);
-    }
-    else
-    {
-        return *cursor++;
-    }
-}
-
-String tryReadCommandLineArgument(wchar_t const* option, wchar_t***ioCursor, wchar_t**end)
-{
-    return String::FromWString(tryReadCommandLineArgumentRaw(option, ioCursor, end));
-}
-
-struct OptionsParser
-{
-    SlangSession*           session = nullptr;
-    SlangCompileRequest*    compileRequest = nullptr;
-
-    struct RawTranslationUnit
-    {
-        SlangSourceLanguage sourceLanguage;
-        SlangProfileID      implicitProfile;
-        int                 translationUnitIndex;
-    };
-
-    // Collect translation units so that we can futz with them later
-    List<RawTranslationUnit> rawTranslationUnits;
-
-    struct RawEntryPoint
-    {
-        String          name;
-        SlangProfileID  profileID = SLANG_PROFILE_UNKNOWN;
-        int             translationUnitIndex = -1;
-    };
-
-    // Collect entry point names, so that we can associate them
-    // with entry points later...
-    List<RawEntryPoint> rawEntryPoints;
-
-    // The number of input files that have been specified
-    int inputPathCount = 0;
-
-    // If we already have a translation unit for Slang code, then this will give its index.
-    // If not, it will be `-1`.
-    int slangTranslationUnit = -1;
-
-    int translationUnitCount = 0;
-    int currentTranslationUnitIndex = -1;
-
-    SlangProfileID currentProfileID = SLANG_PROFILE_UNKNOWN;
-
-    SlangCompileFlags flags = 0;
-
-    int addTranslationUnit(
-        SlangSourceLanguage language,
-        SlangProfileID      implicitProfile = SLANG_PROFILE_UNKNOWN)
-    {
-        auto translationUnitIndex = spAddTranslationUnit(compileRequest, language, nullptr);
-
-        assert(translationUnitIndex == rawTranslationUnits.Count());
-
-        RawTranslationUnit rawTranslationUnit;
-        rawTranslationUnit.sourceLanguage = language;
-        rawTranslationUnit.implicitProfile = implicitProfile;
-        rawTranslationUnit.translationUnitIndex = translationUnitIndex;
-
-        rawTranslationUnits.Add(rawTranslationUnit);
-
-        return translationUnitIndex;
-    }
-
-    void addInputSlangPath(
-        String const& path)
-    {
-        // All of the input .slang files will be grouped into a single logical translation unit,
-        // which we create lazily when the first .slang file is encountered.
-        if( slangTranslationUnit == -1 )
-        {
-            translationUnitCount++;
-            slangTranslationUnit = addTranslationUnit(SLANG_SOURCE_LANGUAGE_SLANG);
-        }
-
-        spAddTranslationUnitSourceFile(
-            compileRequest,
-            slangTranslationUnit,
-            path.begin());
-
-        // Set the translation unit to be used by subsequent entry points
-        currentTranslationUnitIndex = slangTranslationUnit;
-    }
-
-    void addInputForeignShaderPath(
-        String const&           path,
-        SlangSourceLanguage     language,
-        SlangProfileID          implicitProfile = SLANG_PROFILE_UNKNOWN)
-    {
-        translationUnitCount++;
-        currentTranslationUnitIndex = addTranslationUnit(language, implicitProfile);
-
-        spAddTranslationUnitSourceFile(
-            compileRequest,
-            currentTranslationUnitIndex,
-            path.begin());
-    }
-
-    void addInputPath(
-        wchar_t const*  inPath)
-    {
-        inputPathCount++;
-
-        // look at the extension on the file name to determine
-        // how we should handle it.
-        String path = String::FromWString(inPath);
-
-        if( path.EndsWith(".slang") )
-        {
-            // Plain old slang code
-            addInputSlangPath(path);
-        }
-#define CASE(EXT, LANG) \
-        else if(path.EndsWith(EXT)) do { addInputForeignShaderPath(path, SLANG_SOURCE_LANGUAGE_##LANG); } while(0)
-
-        CASE(".hlsl", HLSL);
-        CASE(".fx",   HLSL);
-
-        CASE(".glsl", GLSL);
-#undef CASE
-
-#define CASE(EXT, LANG, PROFILE) \
-        else if(path.EndsWith(EXT)) do { addInputForeignShaderPath(path, SLANG_SOURCE_LANGUAGE_##LANG, SlangProfileID(Slang::Profile::PROFILE)); } while(0)
-        // TODO: need a way to pass along stage/profile and entry-point info for these cases...
-        CASE(".vert", GLSL, GLSL_Vertex);
-        CASE(".frag", GLSL, GLSL_Fragment);
-        CASE(".geom", GLSL, GLSL_Geometry);
-        CASE(".tesc", GLSL, GLSL_TessControl);
-        CASE(".tese", GLSL, GLSL_TessEval);
-        CASE(".comp", GLSL, GLSL_Compute);
-
-#undef CASE
-
-        else
-        {
-            fprintf(stderr, "error: can't deduce language for input file '%S'\n", inPath);
-            exit(1);
-        }
-    }
-
-    void parse(
-        int             argc,
-        wchar_t**       argv)
-    {
-        wchar_t** argCursor = &argv[1];
-        wchar_t** argEnd = &argv[argc];
-        while (argCursor != argEnd)
-        {
-            wchar_t const* arg = *argCursor++;
-            if (arg[0] == '-')
-            {
-                String argStr = String::FromWString(arg);
-
-                // The argument looks like an option, so try to parse it.
-//                if (argStr == "-outdir")
-//                    outputDir = tryReadCommandLineArgument(arg, &argCursor, argEnd);
-//                if (argStr == "-out")
-//                    options.outputName = tryReadCommandLineArgument(arg, &argCursor, argEnd);
-//                else if (argStr == "-symbo")
-//                    options.SymbolToCompile = tryReadCommandLineArgument(arg, &argCursor, argEnd);
-                //else
-                if (argStr == "-no-checking")
-                    flags |= SLANG_COMPILE_FLAG_NO_CHECKING;
-                else if (argStr == "-backend" || argStr == "-target")
-                {
-                    String name = tryReadCommandLineArgument(arg, &argCursor, argEnd);
-                    SlangCompileTarget target = SLANG_TARGET_UNKNOWN;
-
-                    if (name == "glsl")
-                    {
-                        target = SLANG_GLSL;
-                    }
-                    else if (name == "glsl_vk")
-                    {
-                        target = SLANG_GLSL_VULKAN;
-                    }
-//                    else if (name == "glsl_vk_onedesc")
-//                    {
-//                        options.Target = CodeGenTarget::GLSL_Vulkan_OneDesc;
-//                    }
-                    else if (name == "hlsl")
-                    {
-                        target = SLANG_HLSL;
-                    }
-                    else if (name == "spriv")
-                    {
-                        target = SLANG_SPIRV;
-                    }
-                    else if (name == "dxbc")
-                    {
-                        target = SLANG_DXBC;
-                    }
-                    else if (name == "dxbc-assembly")
-                    {
-                        target = SLANG_DXBC_ASM;
-                    }
-                #define CASE(NAME, TARGET)  \
-                    else if(name == #NAME) do { target = SLANG_##TARGET; } while(0)
-
-                    CASE(spirv, SPIRV);
-                    CASE(spirv-assembly, SPIRV_ASM);
-
-                #undef CASE
-
-                    else if (name == "reflection-json")
-                    {
-                        target = SLANG_REFLECTION_JSON;
-                    }
-                    else
-                    {
-                        fprintf(stderr, "unknown code generation target '%S'\n", name.ToWString());
-                        exit(1);
-                    }
-
-                    spSetCodeGenTarget(compileRequest, target);
-                }
-                // A "profile" specifies both a specific target stage and a general level
-                // of capability required by the program.
-                else if (argStr == "-profile")
-                {
-                    String name = tryReadCommandLineArgument(arg, &argCursor, argEnd);
-
-                    SlangProfileID profileID = spFindProfile(session, name.begin());
-                    if( profileID == SLANG_PROFILE_UNKNOWN )
-                    {
-                        fprintf(stderr, "unknown profile '%s'\n", name.begin());
-                    }
-                    else
-                    {
-                        currentProfileID = profileID;
-                    }
-                }
-                else if (argStr == "-entry")
-                {
-                    String name = tryReadCommandLineArgument(arg, &argCursor, argEnd);
-
-                    RawEntryPoint entry;
-                    entry.name = name;
-                    entry.translationUnitIndex = currentTranslationUnitIndex;
-
-                    // TODO(tfoley): Allow user to fold a specification of a profile into the entry-point name,
-                    // for the case where they might be compiling multiple entry points in one invocation...
-                    //
-                    // For now, just use the last profile set on the command-line to specify this
-
-                    entry.profileID = currentProfileID;
-
-                    rawEntryPoints.Add(entry);
-                }
-#if 0
-                else if (argStr == "-stage")
-                {
-                    String name = tryReadCommandLineArgument(arg, &argCursor, argEnd);
-                    StageTarget stage = StageTarget::Unknown;
-                    if (name == "vertex") { stage = StageTarget::VertexShader; }
-                    else if (name == "fragment") { stage = StageTarget::FragmentShader; }
-                    else if (name == "hull") { stage = StageTarget::HullShader; }
-                    else if (name == "domain") { stage = StageTarget::DomainShader; }
-                    else if (name == "compute") { stage = StageTarget::ComputeShader; }
-                    else
-                    {
-                        fprintf(stderr, "unknown stage '%S'\n", name.ToWString());
-                    }
-                    options.stage = stage;
-                }
-#endif
-                else if (argStr == "-pass-through")
-                {
-                    String name = tryReadCommandLineArgument(arg, &argCursor, argEnd);
-                    SlangPassThrough passThrough = SLANG_PASS_THROUGH_NONE;
-                    if (name == "fxc") { passThrough = SLANG_PASS_THROUGH_FXC; }
-                    else if (name == "glslang") { passThrough = SLANG_PASS_THROUGH_GLSLANG; }
-                    else
-                    {
-                        fprintf(stderr, "unknown pass-through target '%S'\n", name.ToWString());
-                        exit(1);
-                    }
-
-                    spSetPassThrough(
-                        compileRequest,
-                        passThrough);
-                }
-//                else if (argStr == "-genchoice")
-//                    options.Mode = CompilerMode::GenerateChoice;
-                else if (argStr[1] == 'D')
-                {
-                    // The value to be defined might be part of the same option, as in:
-                    //     -DFOO
-                    // or it might come separately, as in:
-                    //     -D FOO
-                    wchar_t const* defineStr = arg + 2;
-                    if (defineStr[0] == 0)
-                    {
-                        // Need to read another argument from the command line
-                        defineStr = tryReadCommandLineArgumentRaw(arg, &argCursor, argEnd);
-                    }
-                    // The string that sets up the define can have an `=` between
-                    // the name to be defined and its value, so we search for one.
-                    wchar_t const* eqPos = nullptr;
-                    for(wchar_t const* dd = defineStr; *dd; ++dd)
-                    {
-                        if (*dd == '=')
-                        {
-                            eqPos = dd;
-                            break;
-                        }
-                    }
-
-                    // Now set the preprocessor define
-                    //
-                    if (eqPos)
-                    {
-                        // If we found an `=`, we split the string...
-
-                        spAddPreprocessorDefine(
-                            compileRequest,
-                            String::FromWString(defineStr, eqPos).begin(),
-                            String::FromWString(eqPos+1).begin());
-                    }
-                    else
-                    {
-                        // If there was no `=`, then just #define it to an empty string
-
-                        spAddPreprocessorDefine(
-                            compileRequest,
-                            String::FromWString(defineStr).begin(),
-                            "");
-                    }
-                }
-                else if (argStr[1] == 'I')
-                {
-                    // The value to be defined might be part of the same option, as in:
-                    //     -IFOO
-                    // or it might come separately, as in:
-                    //     -I FOO
-                    // (see handling of `-D` above)
-                    wchar_t const* includeDirStr = arg + 2;
-                    if (includeDirStr[0] == 0)
-                    {
-                        // Need to read another argument from the command line
-                        includeDirStr = tryReadCommandLineArgumentRaw(arg, &argCursor, argEnd);
-                    }
-
-                    spAddSearchPath(
-                        compileRequest,
-                        String::FromWString(includeDirStr).begin());
-                }
-                else if (argStr == "--")
-                {
-                    // The `--` option causes us to stop trying to parse options,
-                    // and treat the rest of the command line as input file names:
-                    while (argCursor != argEnd)
-                    {
-                        addInputPath(*argCursor++);
-                    }
-                    break;
-                }
-                else
-                {
-                    fprintf(stderr, "unknown command-line option '%S'\n", argStr.ToWString());
-                    // TODO: print a usage message
-                    exit(1);
-                }
-            }
-            else
-            {
-                addInputPath(arg);
-            }
-        }
-
-        spSetCompileFlags(compileRequest, flags);
-
-        if (inputPathCount == 0)
-        {
-            fprintf(stderr, "error: no input file specified\n");
-            exit(1);
-        }
-
-        // No point in moving forward if there is nothing to compile
-        if( translationUnitCount == 0 )
-        {
-            fprintf(stderr, "error: no compilation requested\n");
-            exit(1);
-        }
-
-        // If the user didn't list any explicit entry points, then we can
-        // try to infer one from the type of input file
-        if(rawEntryPoints.Count() == 0)
-        {
-            for(auto rawTranslationUnit : rawTranslationUnits)
-            {
-                // Dont' add implicit entry points when compiling from Slang files,
-                // since Slang doesn't require entry points to be named on the
-                // command line.
-                if(rawTranslationUnit.sourceLanguage == SLANG_SOURCE_LANGUAGE_SLANG )
-                    continue;
-
-                // Use a default entry point name
-                char const* entryPointName = "main";
-
-                // Try to determine a profile
-                SlangProfileID entryPointProfile = SLANG_PROFILE_UNKNOWN;
-
-                // If a profile was specified on the command line, then we use it
-                if(currentProfileID != SLANG_PROFILE_UNKNOWN)
-                {
-                    entryPointProfile = currentProfileID;
-                }
-                // Otherwise, check if the translation unit implied a profile
-                // (e.g., a `*.vert` file implies the `GLSL_Vertex` profile)
-                else if(rawTranslationUnit.implicitProfile != SLANG_PROFILE_UNKNOWN)
-                {
-                    entryPointProfile = rawTranslationUnit.implicitProfile;
-                }
-
-                RawEntryPoint entry;
-                entry.name = entryPointName;
-                entry.translationUnitIndex = rawTranslationUnit.translationUnitIndex;
-                entry.profileID = entryPointProfile;
-                rawEntryPoints.Add(entry);
-            }
-        }
-
-        // For any entry points that were given without an explicit profile, we can now apply
-        // the profile that was given to them.
-        if( rawEntryPoints.Count() != 0 )
-        {
-            bool anyEntryPointWithoutProfile = false;
-            for( auto& entryPoint : rawEntryPoints )
-            {
-                // Skip entry points that are already associated with a translation unit...
-                if( entryPoint.profileID != SLANG_PROFILE_UNKNOWN )
-                    continue;
-
-                anyEntryPointWithoutProfile = true;
-                break;
-            }
-
-            if( anyEntryPointWithoutProfile )
-            {
-                fprintf(stderr, "error: no profile specified; use the '-profile <profile name>' option");
-                exit(1);
-            }
-            // TODO: issue an error if we have multiple `-profile` options *and*
-            // there are entry points that didn't get a profile.
-            else
-            {
-                for( auto& e : rawEntryPoints )
-                {
-                    if( e.profileID == SLANG_PROFILE_UNKNOWN )
-                    {
-                        e.profileID = currentProfileID;
-                    }
-                }
-            }
-        }
-
-        // Next, we want to make sure that entry points get attached to the appropriate translation
-        // unit that will provide them.
-        {
-            bool anyEntryPointWithoutTranslationUnit = false;
-            for( auto& entryPoint : rawEntryPoints )
-            {
-                // Skip entry points that are already associated with a translation unit...
-                if( entryPoint.translationUnitIndex != -1 )
-                    continue;
-
-                anyEntryPointWithoutTranslationUnit = true;
-                entryPoint.translationUnitIndex = 0;
-            }
-
-            if( anyEntryPointWithoutTranslationUnit && translationUnitCount != 1 )
-            {
-                fprintf(stderr, "error: when using multiple translation units, entry points must be specified after their translation unit file(s)");
-                exit(1);
-            }
-
-            // Now place all those entry points where they belong
-            for( auto& entryPoint : rawEntryPoints )
-            {
-                spAddTranslationUnitEntryPoint(
-                    compileRequest,
-                    entryPoint.translationUnitIndex,
-                    entryPoint.name.begin(),
-                    entryPoint.profileID);
-            }
-        }
-
-#if 0
-        // Automatically derive an output directory based on the first file specified.
-        //
-        // TODO: require manual specification if there are multiple input files, in different directories
-        String fileName = options.translationUnits[0].sourceFilePaths[0];
-        if (outputDir.Length() == 0)
-        {
-            outputDir = Path::GetDirectoryName(fileName);
-        }
-#endif
-    }
-
-};
-
-
-void parseOptions(
-    SlangCompileRequest*    compileRequest,
-    int                     argc,
-    wchar_t**               argv)
-{
-    OptionsParser parser;
-    parser.compileRequest = compileRequest;
-    parser.parse(argc, argv);
-}
 
 static void diagnosticCallback(
     char const* message,
@@ -547,14 +18,28 @@ static void diagnosticCallback(
     fflush(stderr);
 }
 
-int wmain(int argc, wchar_t* argv[])
+#ifdef _WIN32
+#define MAIN slangc_main
+#else
+#define MAIN main
+#endif
+
+int MAIN(int argc, char** argv)
 {
     // Parse any command-line options
 
     SlangSession* session = spCreateSession(nullptr);
     SlangCompileRequest* compileRequest = spCreateCompileRequest(session);
 
-    parseOptions(compileRequest, argc, argv);
+    char const* appName = "slangc";
+    if(argc > 0) appName = argv[0];
+
+    int err = spProcessCommandLineArguments(compileRequest, &argv[1], argc - 1);
+    if( err )
+    {
+        // TODO: print usage message
+        exit(1);
+    }
 
     spSetDiagnosticCallback(
         compileRequest,
@@ -604,40 +89,29 @@ int wmain(int argc, wchar_t* argv[])
     }
 #endif
 
-#if 0
-        int returnValue = -1;
-    {
-
-
-        auto sourceDir = Path::GetDirectoryName(fileName);
-        CompileResult result;
-        try
-        {
-            auto files = SlangLib::CompileShaderSourceFromFile(result, fileName, options);
-            for (auto & f : files)
-            {
-                try
-                {
-                    f.SaveToFile(Path::Combine(outputDir, f.MetaData.ShaderName + ".cse"));
-                }
-                catch (Exception &)
-                {
-                    result.GetErrorWriter()->diagnose(CodePosition(0, 0, 0, ""), Diagnostics::cannotWriteOutputFile, Path::Combine(outputDir, f.MetaData.ShaderName + ".cse"));
-                }
-            }
-        }
-        catch (Exception & e)
-        {
-            printf("internal compiler error: %S\n", e.Message.ToWString());
-        }
-        result.PrintDiagnostics();
-        if (result.GetErrorCount() == 0)
-            returnValue = 0;
-    }
-#endif
-
 #ifdef _MSC_VER
     _CrtDumpMemoryLeaks();
 #endif
     return 0;
 }
+
+#ifdef _WIN32
+int wmain(int argc, wchar_t** argv)
+{
+    // Conver the wide-character Unicode arguments to UTF-8,
+    // since that is what Slang expects on the API side.
+
+    List<String> args;
+    for(int ii = 0; ii < argc; ++ii)
+    {
+        args.Add(String::FromWString(argv[ii]));
+    }
+    List<char const*> argBuffers;
+    for(int ii = 0; ii < argc; ++ii)
+    {
+        argBuffers.Add(args[ii].Buffer());
+    }
+
+    return MAIN(argc, (char**) &argBuffers[0]);
+}
+#endif


### PR DESCRIPTION
This is to pull in the fix for shader-slang/slang#34, which affected Falcor's `GraphicsStateObjectTest`.

Also includes a change to the Falcor `.gitignore` to try to make sure we don't miss source files that get added to Slang (like how I missed `options.cpp` in a recent pull request).