### PR TITLE
Fixups to shader code for Slang changes

### DIFF
--- a/Framework/Source/ShadingUtils/Helpers.slang
+++ b/Framework/Source/ShadingUtils/Helpers.slang
@@ -268,9 +268,6 @@ void _fn applyNormalMap(in float3 texValue, _ref(float3) n, _ref(float3) t, _ref
     t = normalize(cross(b, n));
 }
 
-// Forward declare it, just in case someone overrides it later
-void _fn perturbNormal(in const MaterialData mat, _ref(ShadingAttribs) attr, bool forceSample = false);
-
 #ifndef _MS_USER_NORMAL_MAPPING
 void _fn perturbNormal(in const MaterialData mat, _ref(ShadingAttribs) attr, bool forceSample)
 {
@@ -280,7 +277,17 @@ void _fn perturbNormal(in const MaterialData mat, _ref(ShadingAttribs) attr, boo
         applyNormalMap(RGBToNormal(texValue), attr.N, attr.T, attr.B);
 	}
 }
+#else
+// Forward declare it, just in case someone overrides it later
+void _fn perturbNormal(in const MaterialData mat, _ref(ShadingAttribs) attr, bool forceSample /*= false*/);
 #endif
+
+// Note: explicit overload instead of default argument, at least until cross-compiler can handle defaults
+void _fn perturbNormal(in const MaterialData mat, _ref(ShadingAttribs) attr)
+{
+	perturbNormal(mat, attr, false);
+}
+
 
 /*******************************************************************
 					Alpha test

--- a/Samples/Effects/Shadows/Data/Shadows.ps.hlsl
+++ b/Samples/Effects/Shadows/Data/Shadows.ps.hlsl
@@ -3,6 +3,7 @@ Copyright (c) 2014, NVIDIA CORPORATION.  All rights reserved.
 ***************************************************************************/
 __import DefaultVS;
 __import Shading;
+__import ShaderCommon;
 __import Effects.CascadedShadowMap;
 
 cbuffer PerFrameCB : register(b0)


### PR DESCRIPTION
- Don't use redeclaration or default parameter values for `perturbNormal`, because these are no longer going to be supported in pure Slang code.

- Make sure to import `ShaderCommon` explicitly into `Shadows.ps.hlsl` since the implicit behavior will no longer work.