### PR TITLE
Matrix convention

### DIFF
--- a/Framework/Source/API/D3D/D3DShader.cpp
+++ b/Framework/Source/API/D3D/D3DShader.cpp
@@ -121,6 +121,7 @@ namespace Falcor
 #ifdef _DEBUG
         flags |= D3DCOMPILE_DEBUG;
 #endif
+        flags |= D3DCOMPILE_PACK_MATRIX_ROW_MAJOR;
 
         HRESULT hr = D3DCompile(
             source.c_str(),

--- a/Framework/Source/Data/DefaultVS.slang
+++ b/Framework/Source/Data/DefaultVS.slang
@@ -94,9 +94,9 @@ VS_OUT defaultVS(VS_IN vIn)
 {
     VS_OUT vOut;
     float4x4 worldMat = getWorldMat(vIn);
-    float4 posW = mul(worldMat, vIn.pos);
+    float4 posW = mul(vIn.pos, worldMat);
     vOut.posW = posW.xyz;
-    vOut.posH = mul(gCam.viewProjMat, posW);
+    vOut.posH = mul(posW, gCam.viewProjMat);
 
 #ifdef HAS_TEXCRD
     vOut.texC = vIn.texC;
@@ -110,12 +110,12 @@ VS_OUT defaultVS(VS_IN vIn)
     vOut.colorV = 0;
 #endif
 
-    vOut.normalW = mul(getWorldInvTransposeMat(vIn), vIn.normal).xyz;
-    vOut.bitangentW = mul((float3x3)worldMat, vIn.bitangent).xyz;
-    vOut.prevPosH = mul(gCam.prevViewProjMat, posW);
+    vOut.normalW = mul(vIn.normal, getWorldInvTransposeMat(vIn)).xyz;
+    vOut.bitangentW = mul(vIn.bitangent, (float3x3)worldMat).xyz;
+    vOut.prevPosH = mul(posW, gCam.prevViewProjMat);
 
 #ifdef _SINGLE_PASS_STEREO
-    vOut.rightEyePosS = mul(gCam.rightEyeViewProjMat, posW).x;
+    vOut.rightEyePosS = mul(posW, gCam.rightEyeViewProjMat).x;
     vOut.viewportMask = 0x00000001;
     vOut.renderTargetIndex = 0;
 #endif

--- a/Framework/Source/Data/Effects/CascadedShadowMap.slang
+++ b/Framework/Source/Data/Effects/CascadedShadowMap.slang
@@ -250,7 +250,7 @@ float calcShadowFactorWithCascadeIdx(const CsmData csmData, const uint32_t casca
     //posW.xyz += calcNormalOffset(csmData, normal, cascadeIndex);
 
     // Get the global shadow space position
-    float4 shadowPos = mul(csmData.globalMat, float4(posW, 1));
+    float4 shadowPos = mul(float4(posW, 1), csmData.globalMat);
     shadowPos /= shadowPos.w;
 
     // Calculate the texC

--- a/Framework/Source/Data/Effects/ParticleSimulate.cs.slang
+++ b/Framework/Source/Data/Effects/ParticleSimulate.cs.slang
@@ -87,7 +87,7 @@ void main(uint3 groupID : SV_GroupID, uint groupIndex : SV_GroupIndex)
         #ifdef _SORT
             SortData data;
             data.index = index;
-            data.depth = mul(perFrame.view, float4(particlePool[index].pos, 1.f)).z;
+            data.depth = mul(float4(particlePool[index].pos, 1.f), perFrame.view).z;
             aliveList.Append(data);
         #else
             aliveList.Append(index);

--- a/Framework/Source/Data/Effects/ParticleVertex.vs.slang
+++ b/Framework/Source/Data/Effects/ParticleVertex.vs.slang
@@ -71,10 +71,10 @@ VSOut main(uint vId : SV_VertexID, uint iId : SV_InstanceID)
     Particle p = particlePool[poolIndex];
     uint billboardIndex = vId;
 
-    float4 viewPos = mul(frameData.view, float4(p.pos, 1.f));
+    float4 viewPos = mul(float4(p.pos, 1.f), frameData.view);
     float2 rotOffset = vectorRotate(float2(xOffset[billboardIndex], yOffset[billboardIndex]), sin(p.rot), cos(p.rot));
     viewPos.xy += float2(p.scale, p.scale) * rotOffset;
-    output.pos = mul(frameData.proj, viewPos);
+    output.pos = mul(viewPos, frameData.proj);
     output.texCoords = float2(xTex[billboardIndex], yTex[billboardIndex]);
     output.particleIndex = poolIndex;
     return output;

--- a/Framework/Source/Data/Effects/SSAO.ps.slang
+++ b/Framework/Source/Data/Effects/SSAO.ps.slang
@@ -47,7 +47,7 @@ float4 getPosition(float2 uv)
     pos.z = gDepthTex.SampleLevel(gSampler, uv, 0).r;
     pos.w = 1.0f;
 
-    float4 posW = mul(gCam.invViewProj, pos);
+    float4 posW = mul(pos, gCam.invViewProj);
     posW /= posW.w;
 
     return posW;
@@ -96,7 +96,7 @@ float4 main(float2 texC : TEXCOORD) : SV_TARGET0
         float sampleDepth = length(samplePosW - gCam.position);
 
         // Get screen space pos of sample
-        float4 samplePosProj = mul(gCam.viewProjMat, float4(samplePosW, 1.0f));
+        float4 samplePosProj = mul(float4(samplePosW, 1.0f), gCam.viewProjMat);
         samplePosProj /= samplePosProj.w;
 
         // Sample depth buffer at the same place as sample

--- a/Framework/Source/Data/Effects/ShadowPass.gs.slang
+++ b/Framework/Source/Data/Effects/ShadowPass.gs.slang
@@ -55,7 +55,7 @@ void main(triangle ShadowPassVSOut input[3], uint InstanceID : SV_GSInstanceID, 
 
     for(int i = 0 ; i < 3 ; i++)
     {
-        outputData.pos = mul(gCsmData.globalMat, input[i].pos);
+        outputData.pos = mul(input[i].pos, gCsmData.globalMat);
         outputData.pos.xyz /= input[i].pos.w;
         outputData.pos.xyz *= gCsmData.cascadeScale[InstanceID].xyz;
         outputData.pos.xyz += gCsmData.cascadeOffset[InstanceID].xyz;

--- a/Framework/Source/Data/Effects/ShadowPass.vs.slang
+++ b/Framework/Source/Data/Effects/ShadowPass.vs.slang
@@ -42,9 +42,9 @@ ShadowPassVSOut main(VS_IN vIn)
 {
     ShadowPassVSOut vOut; 
     float4x4 worldMat = getWorldMat(vIn);
-    vOut.pos = mul(worldMat, vIn.pos);
+    vOut.pos = mul(vIn.pos, worldMat);
 #ifdef _APPLY_PROJECTION
-    vOut.pos = mul(gCam.viewProjMat, vOut.pos);
+    vOut.pos = mul(vOut.pos, gCam.viewProjMat);
 #endif
 
 #ifdef HAS_TEXCRD

--- a/Framework/Source/Data/Effects/SkyBox.vs.slang
+++ b/Framework/Source/Data/Effects/SkyBox.vs.slang
@@ -40,8 +40,8 @@ cbuffer PerFrameCB : register(b0)
 void main(float4 posL : POSITION, out float3 dir : NORMAL, out float4 posH : SV_POSITION)
 {
     dir = posL.xyz;
-    float4 viewPos = mul(gCam.viewMat, mul(gWorld, posL));
-    posH = mul(gCam.projMat, viewPos);
+    float4 viewPos = mul(mul(posL, gWorld), gCam.viewMat);
+    posH = mul(viewPos, gCam.projMat);
     posH.xy *= gScale;
     posH.z = posH.w;
 

--- a/Framework/Source/Data/Framework/Shaders/SceneEditorVS.slang
+++ b/Framework/Source/Data/Framework/Shaders/SceneEditorVS.slang
@@ -34,7 +34,7 @@ DebugDrawVSOut main(DebugDrawVSIn vIn)
 {
     DebugDrawVSOut vOut;
 
-    vOut.position =  mul(gCam.viewProjMat, float4(vIn.position, 1));
+    vOut.position =  mul(float4(vIn.position, 1), gCam.viewProjMat);
     vOut.color = vIn.color;
 
     return vOut;

--- a/Framework/Source/Data/Framework/Shaders/TextRenderer.vs
+++ b/Framework/Source/Data/Framework/Shaders/TextRenderer.vs
@@ -36,7 +36,7 @@ cbuffer PerFrameCB : register(b0)
 
 void main(float2 posS : POSITION, inout float2 texC : TEXCOORD, out float4 posSV : SV_POSITION)
 {
-	posSV = mul(gvpTransform, float4(posS, 0.5f, 1));
+	posSV = mul(float4(posS, 0.5f, 1), gvpTransform);
 }
 #endif
 #ifdef FALCOR_GLSL

--- a/Framework/Source/Data/Framework/Shaders/TextRenderer.vs.slang
+++ b/Framework/Source/Data/Framework/Shaders/TextRenderer.vs.slang
@@ -34,7 +34,7 @@ cbuffer PerFrameCB : register(b0)
 
 float4 transform(float2 posS)
 {
-	return mul(gvpTransform, float4(posS, 0.5f, 1));
+	return mul(float4(posS, 0.5f, 1), gvpTransform);
 }
 
 void main(

--- a/Framework/Source/ShadingUtils/Helpers.slang
+++ b/Framework/Source/ShadingUtils/Helpers.slang
@@ -268,9 +268,6 @@ void _fn applyNormalMap(in float3 texValue, _ref(float3) n, _ref(float3) t, _ref
     t = normalize(cross(b, n));
 }
 
-// Forward declare it, just in case someone overrides it later
-void _fn perturbNormal(in const MaterialData mat, _ref(ShadingAttribs) attr, bool forceSample = false);
-
 #ifndef _MS_USER_NORMAL_MAPPING
 void _fn perturbNormal(in const MaterialData mat, _ref(ShadingAttribs) attr, bool forceSample)
 {
@@ -280,7 +277,17 @@ void _fn perturbNormal(in const MaterialData mat, _ref(ShadingAttribs) attr, boo
         applyNormalMap(RGBToNormal(texValue), attr.N, attr.T, attr.B);
 	}
 }
+#else
+// Forward declare it, just in case someone overrides it later
+void _fn perturbNormal(in const MaterialData mat, _ref(ShadingAttribs) attr, bool forceSample /*= false*/);
 #endif
+
+// Note: explicit overload instead of default argument, at least until cross-compiler can handle defaults
+void _fn perturbNormal(in const MaterialData mat, _ref(ShadingAttribs) attr)
+{
+	perturbNormal(mat, attr, false);
+}
+
 
 /*******************************************************************
 					Alpha test

--- a/Framework/Source/ShadingUtils/Lights.slang
+++ b/Framework/Source/ShadingUtils/Lights.slang
@@ -65,7 +65,7 @@ inline float3 _fn getLightPos(in const LightData Light, in const float3 shadingP
     float3 lightPos = Light.worldPos;
     if(Light.type == LightArea)
     {
-        lightPos = mul(Light.transMat, float4(lightPos, 1.0)).xyz;
+        lightPos = mul(float4(lightPos, 1.0), Light.transMat).xyz;
     }    
     else if(Light.type == LightDirectional)
     {
@@ -167,7 +167,7 @@ inline void _fn prepareLightAttribs(in const LightData Light, in const ShadingAt
 			float3 p0 = float3(vertices[index * 3 + 0], vertices[index * 3 + 1], vertices[index * 3 + 2]);
 #endif
 			// Apply model instance transformation matrix
-			LightAttr.points[index] = float3(mul(Light.transMat, float4(p0, 1.0)));
+			LightAttr.points[index] = float3(mul(float4(p0, 1.0), Light.transMat));
 		}
 	}
 #endif
@@ -245,9 +245,9 @@ void _fn sampleLight(in const float3 shadingHitPos, in const LightData lData, co
 #endif
 
 				// Apply model instance transformation matrix
-				p0 = float3(mul(lData.transMat, float4(p0, 1.0)));
-				p1 = float3(mul(lData.transMat, float4(p1, 1.0)));
-				p2 = float3(mul(lData.transMat, float4(p2, 1.0)));
+				p0 = float3(mul(float4(p0, 1.0), lData.transMat));
+				p1 = float3(mul(float4(p1, 1.0), lData.transMat));
+				p2 = float3(mul(float4(p2, 1.0), lData.transMat));
 
 				// Sample a point on the triangle mesh using barycentric coordinates
 				float a = sqrt(rSample.x);
@@ -287,12 +287,12 @@ void _fn stratifiedSampleRectangularAreaLight(in const float3 shadingHitPos, in 
 		return;
 
 	// Transform light position and light normal
-	float3 lightPos = mul(lData.transMat, float4(lData.worldPos, 1.0f)).rgb;
-	lAttr.N = mul(lData.transMat, float4(lData.worldDir, 0.0f)).rgb;
+	float3 lightPos = mul(float4(lData.worldPos, 1.0f), lData.transMat).rgb;
+	lAttr.N = mul(float4(lData.worldDir, 0.0f), lData.transMat).rgb;
 
 	// Transform tangent frame
-	float3 transformedTangent = mul(lData.transMat, float4(lData.tangent, 0.0f)).rgb;
-	float3 transformedBitangent = mul(lData.transMat, float4(lData.bitangent, 0.0f)).rgb;
+	float3 transformedTangent = mul(float4(lData.tangent, 0.0f), lData.transMat).rgb;
+	float3 transformedBitangent = mul(float4(lData.bitangent, 0.0f), lData.transMat).rgb;
 
 	float lightSizeY1 = length(transformedTangent);
 	float lightSizeY2 = length(transformedBitangent);

--- a/Samples/Core/ShaderBuffers/Data/ShaderBuffers.vs.hlsl
+++ b/Samples/Core/ShaderBuffers/Data/ShaderBuffers.vs.hlsl
@@ -43,8 +43,8 @@ VSOut main(in float4 posL : POSITION, in float3 normalL : NORMAL)
 {
     VSOut vsOut;
 
-    vsOut.position = mul(gWvpMat, posL);
-    vsOut.normalW = (mul(gWorldMat, float4(normalL, 0))).xyz;
+    vsOut.position = mul(posL, gWvpMat);
+    vsOut.normalW = (mul(float4(normalL, 0), gWorldMat)).xyz;
 
     return vsOut;
 }

--- a/Samples/Effects/PostProcess/Data/PostProcess.vs.hlsl
+++ b/Samples/Effects/PostProcess/Data/PostProcess.vs.hlsl
@@ -50,8 +50,8 @@ struct PostProcessOut
 PostProcessOut main(PostProcessIn vIn)
 {
     PostProcessOut vOut;
-    vOut.pos = (mul(gWvpMat, vIn.pos));
-    vOut.posW = (mul(gWvpMat, vIn.pos)).xyz;
-	vOut.normalW = (mul(gWorldMat, float4(vIn.normal, 0))).xyz;
+    vOut.pos = (mul(vIn.pos, gWvpMat));
+    vOut.posW = (mul(vIn.pos, gWvpMat)).xyz;
+	vOut.normalW = (mul(float4(vIn.normal, 0), gWorldMat)).xyz;
     return vOut;
 }

--- a/Samples/Effects/Shadows/Data/Shadows.ps.hlsl
+++ b/Samples/Effects/Shadows/Data/Shadows.ps.hlsl
@@ -3,6 +3,7 @@ Copyright (c) 2014, NVIDIA CORPORATION.  All rights reserved.
 ***************************************************************************/
 __import DefaultVS;
 __import Shading;
+__import ShaderCommon;
 __import Effects.CascadedShadowMap;
 
 cbuffer PerFrameCB : register(b0)

--- a/Samples/Effects/Shadows/Data/Shadows.vs.hlsl
+++ b/Samples/Effects/Shadows/Data/Shadows.vs.hlsl
@@ -49,6 +49,6 @@ ShadowsVSOut main(VS_IN vIn)
     ShadowsVSOut output;
     output.vsData = defaultOut;
 
-    output.shadowsDepthC = mul(camVpAtLastCsmUpdate, float4(defaultOut.posW, 1)).z;
+    output.shadowsDepthC = mul(float4(defaultOut.posW, 1), camVpAtLastCsmUpdate).z;
     return output;
 }

--- a/Samples/FeatureDemo/Data/FeatureDemo.ps.hlsl
+++ b/Samples/FeatureDemo/Data/FeatureDemo.ps.hlsl
@@ -27,6 +27,7 @@
 ***************************************************************************/
 #include "FeatureDemoCommon.hlsli"
 
+__import BSDFs;
 __import Shading;
 __import Helpers;
 

--- a/Samples/FeatureDemo/Data/FeatureDemo.vs.hlsl
+++ b/Samples/FeatureDemo/Data/FeatureDemo.vs.hlsl
@@ -31,6 +31,6 @@ MainVsOut main(VS_IN vIn)
 {
     MainVsOut vsOut;
     vsOut.vsData = defaultVS(vIn);
-    vsOut.shadowsDepthC = mul(camVpAtLastCsmUpdate, float4(vsOut.vsData.posW, 1)).z;
+    vsOut.shadowsDepthC = mul(float4(vsOut.vsData.posW, 1), camVpAtLastCsmUpdate).z;
     return vsOut;
 }


### PR DESCRIPTION
The main change here is to switch the default matrix convention for HLSL code from `mul(m,v)` over to `mul(v,m)`, while keeping in-memory layout unchanged.

There are additional changes here to fix up some Slang code in the Falcor shader library to not trigger errors with the improved rewriter (as cross-compilation support comes online, some HLSL stuff is breaking as the compiler has to get less lenient). The first of these is already present in an earlier PR.