### PR TITLE
Shader fixes to enable cross-compilation of ModelViewer

### DIFF
--- a/Framework/Source/Data/HostDeviceSharedCode.h
+++ b/Framework/Source/Data/HostDeviceSharedCode.h
@@ -200,6 +200,12 @@ struct MaterialData
     SamplerState samplerState;  // The sampler state to use when sampling the object
 };
 
+struct PreparedMaterialData
+{
+    MaterialDesc    desc;
+    MaterialValues  values;
+};
+
 /**
     The structure stores the complete information about the shading point,
     except for a light source information.
@@ -226,7 +232,7 @@ struct ShadingAttribs
     float2    DHDX            DEFAULTS(float2(0, 0));
     float2    DHDY            DEFAULTS(float2(0, 0));  ///< User-defined half-vector derivatives
 #endif
-    MaterialData preparedMat;                   ///< Copy of the original material with evaluated parameters (i.e., textures are fetched etc.)
+    PreparedMaterialData preparedMat;               ///< Copy of the original material with evaluated parameters (i.e., textures are fetched etc.)
     float aoFactor;
 };
 

--- a/Framework/Source/ShadingUtils/Shading.slang
+++ b/Framework/Source/ShadingUtils/Shading.slang
@@ -151,11 +151,9 @@ void _fn prepareShadingAttribs(in const MaterialData material, in float3 P, in f
 
     shAttr.preparedMat.values = material.values;
     shAttr.preparedMat.desc = desc;
-    shAttr.preparedMat.textures = material.textures;
-    shAttr.preparedMat.samplerState = material.samplerState;
 
     /* Evaluate alpha test material modifier */
-    applyAlphaTest(shAttr.preparedMat, shAttr);
+    applyAlphaTest(material, shAttr);
     shAttr.aoFactor = 1;
 
     /* Prefetch textures */
@@ -169,7 +167,7 @@ void _fn prepareShadingAttribs(in const MaterialData material, in float3 P, in f
     }
 
     /* Perturb shading normal is needed */
-    perturbNormal(shAttr.preparedMat, shAttr);
+    perturbNormal(material, shAttr);
 }
 
 /**
@@ -546,7 +544,7 @@ Tries to find a layer data for a given material type (diffuse/conductor/etc).
 \param[out] data           Layer data, if found
 returns false if the layer is not found, true otherwise
 */
-bool _fn getLayerByType(in const MaterialData material, in const uint layerType, _ref(MaterialLayerValues) data, _ref(MaterialLayerDesc) desc)
+bool _fn getLayerByType(in const PreparedMaterialData material, in const uint layerType, _ref(MaterialLayerValues) data, _ref(MaterialLayerDesc) desc)
 {
     int layerId = material.desc.layerIdByType[layerType].id;
     if(layerId != -1)


### PR DESCRIPTION
- These changes rely on Slang fixes that will come in separately on the `slang-update` branch (following the normal Slang integration process)

- The main fix here is ditching the textures that were inside the `preparedMat` field, and then propagating that change around

- A few calls that used to take `preparedMat`, but which fetched textures, have been changed to take `material`. Hopefully this isn't broken, but if it is they should be updated to take both `material` and `preparedMat`.