### PR TITLE
Fixed "undefined identifier" error in `GraphicsStateObjectTest`

### DIFF
--- a/Test/Tests/LowLevelTests/GraphicsStateObjectTest/Data/Simple.gs.hlsl
+++ b/Test/Tests/LowLevelTests/GraphicsStateObjectTest/Data/Simple.gs.hlsl
@@ -25,6 +25,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***************************************************************************/
+__import DefaultVS;
 __import ShaderCommon;
 __import Shading;
 


### PR DESCRIPTION
The `Simple.gs.hlsl` shader was using `VS_OUT` without importing `DefaultVS`.
This issue has been masked by lenient Slang compiler behavior before, and then when the Slang compiler behavior got more strict, the error led Slang down a path where it assert-failed.
I am working on a fix for the Slang crash, but this change is needed to fix the actual shader issue.