### PR TITLE
GLSL shader fixes for Shadows sample

### DIFF
--- a/Samples/Effects/Shadows/Data/Shadows.vs.glsl
+++ b/Samples/Effects/Shadows/Data/Shadows.vs.glsl
@@ -37,24 +37,16 @@ layout(set = 0, binding = 0) uniform PerFrameCB
     mat4 camVpAtLastCsmUpdate;
 };
 
-layout(location = 0) out vec3 normalW;
-layout(location = 1) out vec3 bitangentW;
-layout(location = 2) out vec2 texC;
-layout(location = 3) out vec3 posW;
-layout(location = 4) out vec3 colorV;
-layout(location = 5) out vec4 prevPosH;
-layout(location = 6) out float shadowsDepthC : DEPTH;
-VS_IN vIn;
+in VS_IN vIn;
+
+out VS_OUT vOut;
+
+out float shadowsDepthC;
 
 void main()
 {
     VS_OUT defaultOut = defaultVS(vIn);
-    normalW = defaultOut.normalW;
-    bitangentW = defaultOut.bitangentW;
-    texC = defaultOut.texC;
-    posW = defaultOut.posW;
-    colorV = defaultOut.colorV;
-    prevPosH = defaultOut.prevPosH;
 
-    shadowsDepthC = (camVpAtLastCsmUpdate * vec4(posW, 1)).z;
+    vOut = defaultOut;
+    shadowsDepthC = (camVpAtLastCsmUpdate * vec4(defaultOut.posW, 1)).z;
 }

--- a/Samples/Effects/Shadows/Data/VisualizeMap.ps.glsl
+++ b/Samples/Effects/Shadows/Data/VisualizeMap.ps.glsl
@@ -25,9 +25,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***************************************************************************/
-layout(set = 0, binding = 0) uniform sampler gSampler;
-
-cbuffer PerImageCB : register(b0)
+layout(set = 0, binding = 0)
+uniform PerImageCB
 {
     int cascade;
 };
@@ -38,15 +37,17 @@ layout(set = 0, binding = 1) uniform texture2DArray gTexture;
 layout(set = 0, binding = 1) uniform texture2D gTexture;
 #endif
 
+layout(set = 0, binding = 2) uniform sampler gSampler;
+
 layout(location = 0) in vec2 texC;
 layout(location = 0) out vec4 fragColor;
 
 void main()
 {
 #ifdef _USE_2D_ARRAY
-	float d = textureLod(sampler2DArray(gTexture, gSampler), vec3(texC, float(cascade)), 0).r
+    float d = textureLod(sampler2DArray(gTexture, gSampler), vec3(texC, float(cascade)), 0).r;
 #else
     float d = textureLod(sampler2D(gTexture, gSampler), texC, 0).r;
 #endif
-    fragColor = vec4(d.xxx, 1);
+    fragColor = vec4(vec3(d), 1);
 }


### PR DESCRIPTION
- Some of this is fixing just plain old bad GLSL code

- Other stuff relies on upcoming Slang features to work (e.g., the fixes for `VS_IN` and `VS_OUT`)