### PR TITLE
Fix gaussian blur kernel to use Slang compile-time loop

### DIFF
--- a/Framework/Source/Data/Effects/GaussianBlur.ps.slang
+++ b/Framework/Source/Data/Effects/GaussianBlur.ps.slang
@@ -45,23 +45,29 @@ struct BlurPSIn
 Buffer<float> weights;
 
 #ifdef _USE_TEX2D_ARRAY
-float4 blur(float2 texC, const float2 direction, uint arrayIndex)
+float4 blur(float2 texC, uint arrayIndex)
 #else
-float4 blur(float2 texC, const float2 direction)
+float4 blur(float2 texC)
 #endif
 {
-   int2 offset = -(_KERNEL_WIDTH / 2) * direction;
+#ifdef _HORIZONTAL_BLUR
+    const float2 dir = float2(1, 0);
+#elif defined _VERTICAL_BLUR
+    const float2 dir = float2(0, 1);
+#else
+    Error. Need to define either _HORIZONTAL_BLUR or _VERTICAL_BLUR
+#endif
+
+   const int2 offset = -(_KERNEL_WIDTH / 2) * dir;
 
     float4 c = float4(0,0,0,0);
-    [unroll(_KERNEL_WIDTH)]
-    for(int i = 0 ; i < _KERNEL_WIDTH ; i++)
+    $for(i in Range(_KERNEL_WIDTH))
     {
 #ifdef _USE_TEX2D_ARRAY
-        c += gSrcTex.SampleLevel(gSampler, float3(texC, arrayIndex), 0, offset)*weights[i];
+        c += gSrcTex.SampleLevel(gSampler, float3(texC, arrayIndex), 0, offset + i*dir)*weights[i];
 #else
-        c += gSrcTex.SampleLevel(gSampler, texC, 0, offset)*weights[i];
+        c += gSrcTex.SampleLevel(gSampler, texC, 0, offset + i*dir)*weights[i];
 #endif
-        offset += direction;
     }
     return c;
 }
@@ -69,18 +75,11 @@ float4 blur(float2 texC, const float2 direction)
 float4 main(BlurPSIn pIn) : SV_TARGET0
 {
     float4 fragColor = float4(1.f, 1.f, 1.f, 1.f);
-#ifdef _HORIZONTAL_BLUR
-    float2 dir = float2(1, 0);
-#elif defined _VERTICAL_BLUR
-    float2 dir = float2(0, 1);
-#else
-    Error. Need to define either _HORIZONTAL_BLUR or _VERTICAL_BLUR
-#endif
 
 #ifdef _USE_TEX2D_ARRAY
-    fragColor = blur(pIn.texC, dir, pIn.arrayIndex);
+    fragColor = blur(pIn.texC, pIn.arrayIndex);
 #else
-    fragColor = blur(pIn.texC, dir);
+    fragColor = blur(pIn.texC);
 #endif
     return fragColor;
 }


### PR DESCRIPTION
Both HLSL and GLSL require that the texel offset in a fetch-with-offset call be a compile-time constant, but HLSL is willing to go to heroics to ensure this, while GLSL will often just given an error.
In particular, putting an `[unroll]` on a loop gives no strong guarantees, because GLSL doesn't have that construct.

New Slang changes will add a compile-time loop construct, and these are shader changes designed to take advantage of it.
Using the looping construct is only part of the fix, since we also need to avoid passing things as function parameters that we need to be visible compile-time-constant.