### PR TITLE
Fix Slang shader code for AMD

### DIFF
--- a/Framework/Source/ShadingUtils/BSDFs.slang
+++ b/Framework/Source/ShadingUtils/BSDFs.slang
@@ -46,7 +46,7 @@ Microfacet routines: Fresnel (conductor/dielectric), shadowing/masking
 /**
 Schlick's approximation for reflection of a dielectric media
 */
-float _fn dielectricFresnelSchlick(in const float VdH, in const float IoR)
+float _fn dielectricFresnelSchlick(float VdH, float IoR)
 {
     float R0 = (1.f - IoR) / (1.f + IoR);	R0 *= R0;
     const float OneMinusCos = 1.f - VdH;
@@ -58,7 +58,7 @@ float _fn dielectricFresnelSchlick(in const float VdH, in const float IoR)
 Simplified Fresnel factor (w/o polarization) of a planar interface
 between two dielectrics
 */
-float _fn dielectricFresnelFast(in const float NdE, in const float NdL, in const float IoR)
+float _fn dielectricFresnelFast(float NdE, float NdL, float IoR)
 {
     const float Rs = (NdE - IoR * NdL) / (NdE + IoR * NdL);	// Transmitted-to-incident wave ratio, perpendicular component
     const float Rp = (IoR * NdE - NdL) / (IoR * NdE + NdL);	// Transmitted-to-incident wave ratio, parallel component
@@ -69,7 +69,7 @@ float _fn dielectricFresnelFast(in const float NdE, in const float NdL, in const
 Full Fresnel factor (w/o polarization) of a planar interface
 between two dielectrics
 */
-float _fn dielectricFresnel(in float NdE, in const float IoR)
+float _fn dielectricFresnel(in float NdE, float IoR)
 {
     const float realIoR = (NdE >= 0.f) ? 1.f / IoR : IoR;
     // Perform a refraction
@@ -87,7 +87,7 @@ float _fn dielectricFresnel(in float NdE, in const float IoR)
 Full Fresnel factor (w/o polarization) of a planar interface
 between a dielectric (usually air) and a conductive media
 */
-float _fn conductorFresnel(in float NdE, in const float IoR, in const float Kappa)
+float _fn conductorFresnel(in float NdE, float IoR, float Kappa)
 {
     const float Kappa2 = Kappa * Kappa;
     const float TotalIoR2 = IoR * IoR + Kappa2;	// Total magnitude of IoR: Real plus complex parts of IoR
@@ -106,7 +106,7 @@ Distribution functions
 /*******************************************************************************************
 Lambertian diffuse BSDF. Returns a clamped N.L factor.
 */
-float _fn evalDiffuseBSDF(in const float3 shadeNormal, in const float3 lightDir)
+float _fn evalDiffuseBSDF(float3 shadeNormal, float3 lightDir)
 {
     return max(0.f, dot(shadeNormal, lightDir)) * M_1_PIf;
 }
@@ -126,7 +126,7 @@ float _fn evalPhongDistribution(in float3 N, in float3 V, in float3 L, in float 
 /*******************************************************************************************
 Beckmann normal distribution function (NDF).
 */
-float _fn evalBeckmannDistribution(in const float3 N, in const float3 H, in float roughness)
+float _fn evalBeckmannDistribution(float3 N, float3 H, in float roughness)
 {
     const float a2 = roughness * roughness;
     // dot products that we need
@@ -137,7 +137,7 @@ float _fn evalBeckmannDistribution(in const float3 N, in const float3 H, in floa
     return exp(-exponent) / (M_PIf * a2 * NoH2 * NoH2);
 }
 
-float _fn evalBeckmannDistribution(in const float3 H, in const float2 rgns)
+float _fn evalBeckmannDistribution(float3 H, float2 rgns)
 {
     const float NoH2 = H.z * H.z;
     const float2 Hproj = float2(H.x, H.y);
@@ -150,7 +150,7 @@ float _fn evalBeckmannDistribution(in const float3 H, in const float2 rgns)
 Returns a standard deviation of the Beckmann distribution
 as a cone apex angle in parallel plane domain based on the roughness.
 */
-float _fn beckmannStdDevAngle(in const float roughness)
+float _fn beckmannStdDevAngle(float roughness)
 {
     return atan(sqrt(0.5f) * roughness);
 }
@@ -162,8 +162,8 @@ N is the normal direction
 R is the mirror vector
 This approximation works fine for G smith correlated and uncorrelated
 */
-float3 _fn getBeckmannDominantDir(in const float3 N, in const float3 R,
-    in const float roughness)
+float3 _fn getBeckmannDominantDir(float3 N, float3 R,
+    float roughness)
 {
     const float smoothness = clamp(1.f - roughness, 0.0f, 1.0f);
     const float lerpFactor = smoothness * (sqrt(smoothness) + roughness);
@@ -175,7 +175,7 @@ float3 _fn getBeckmannDominantDir(in const float3 N, in const float3 R,
 /*******************************************************************************************
 GGX normal distribution function (NDF).
 */
-float _fn evalGGXDistribution(in const float3 N, in const float3 H, in const float roughness)
+float _fn evalGGXDistribution(float3 N, float3 H, float roughness)
 {
     // This doesn't look correct, so disabled    
     const float a2 = roughness * roughness;
@@ -187,7 +187,7 @@ float _fn evalGGXDistribution(in const float3 N, in const float3 H, in const flo
     return a2 / D_denom;
 }
 
-float _fn evalGGXDistribution(in const float3 H, in const float2 rgns)
+float _fn evalGGXDistribution(float3 H, float2 rgns)
 {
     // Numerically robust (w.r.t rgns=0) implementation of anisotropic GGX
     const float anisoU = rgns.y < rgns.x ? rgns.y / rgns.x : 1.f;
@@ -227,7 +227,7 @@ Computes the Smith'67 shadowing or masking term from a direction.
 \param[in] ndfType type of NDF. Only Beckmann and GGX are supported so far
 returns amount of visible microfacets
 */
-float _fn GSmith(const in float3 dir, const in float3 h, const in float2 rghns, in const uint ndfType)
+float _fn GSmith(const in float3 dir, const in float3 h, const in float2 rghns, uint ndfType)
 {
     if(dot(dir, h) * dir.z <= 0.f)
         return 0.f;
@@ -254,9 +254,9 @@ float _fn GSmith(const in float3 dir, const in float3 h, const in float2 rghns, 
 /**
 Computes shadowing and masking term for microfacet BRDFs
 */
-float _fn evalMicrofacetTerms(in const float3 T, in const float3 B, in const float3 N,
-    in const float3 h, in const float3 V, in const float3 L,
-    in const float2 roughness, in const uint ndfType, bool transmissive)
+float _fn evalMicrofacetTerms(float3 T, float3 B, float3 N,
+    float3 h, float3 V, float3 L,
+    float2 roughness, uint ndfType, bool transmissive)
 {
     const float3 lTg = float3(dot(T, L), dot(B, L), dot(N, L));
     const float3 vTg = float3(dot(T, V), dot(B, V), dot(N, V));
@@ -284,9 +284,9 @@ float _fn evalMicrofacetTerms(in const float3 T, in const float3 B, in const flo
     \param[out] pdf Probability density function for choosing the incident direction
 */
 float _fn sampleBeckmannDistribution(
-	in const float3 wo,
-	in const float2 roughness,
-	in const float2 rSample,
+	float3 wo,
+	float2 roughness,
+	float2 rSample,
 	_ref(float3) m,
 	_ref(float3) wi,
 	_ref(float) pdf)
@@ -340,9 +340,9 @@ float _fn sampleBeckmannDistribution(
     \param[out] pdf Probability density function for choosing the incident direction
 */
 float _fn sampleGGXDistribution(
-	in const float3 wo,
+	float3 wo,
 	in float2 roughness,
-	in const float2 rSample,
+	float2 rSample,
 	_ref(float3) m,
 	_ref(float3) wi,
 	_ref(float) pdf)

--- a/Framework/Source/ShadingUtils/Helpers.slang
+++ b/Framework/Source/ShadingUtils/Helpers.slang
@@ -178,7 +178,7 @@ _fn float3 refract(const float3 I, const float3 N, float eta)
 					Geometric routines
 *******************************************************************/
 
-void _fn createTangentFrame(in const float3 normal, _ref(float3) bitangent)
+void _fn createTangentFrame(float3 normal, _ref(float3) bitangent)
 {
 	if(abs(normal.x) > abs(normal.y))
 		bitangent = float3(normal.z, 0.f, -normal.x) / length(float2(normal.x, normal.z));
@@ -218,7 +218,7 @@ float4 _fn sampleTexture(Texture2DArray t, SamplerState s, const ShadingAttribs 
 }
 #endif
 
-float4 _fn evalTex(in uint32_t hasTexture, in const Texture2D tex, SamplerState s, in const ShadingAttribs attr, in float4 defaultValue)
+float4 _fn evalTex(in uint32_t hasTexture, Texture2D tex, SamplerState s, ShadingAttribs attr, in float4 defaultValue)
 {
 #ifndef _MS_DISABLE_TEXTURES
 	if(hasTexture != 0)
@@ -230,7 +230,7 @@ float4 _fn evalTex(in uint32_t hasTexture, in const Texture2D tex, SamplerState 
 	return defaultValue;
 }
 
-float4 _fn evalWithColor(in uint32_t hasTexture, in const Texture2D tex, SamplerState s, float4 color, in const ShadingAttribs attr)
+float4 _fn evalWithColor(in uint32_t hasTexture, Texture2D tex, SamplerState s, float4 color, ShadingAttribs attr)
 {
 	return evalTex(hasTexture, tex, s, attr, color);
 }
@@ -239,12 +239,12 @@ float4 _fn evalWithColor(in uint32_t hasTexture, in const Texture2D tex, Sampler
 					Normal mapping
 *******************************************************************/
 
-float3 _fn normalToRGB(in const float3 normal)
+float3 _fn normalToRGB(float3 normal)
 {
 	return normal * 0.5f + 0.5f;
 }
 
-float3 _fn RGBToNormal(in const float3 rgbval)
+float3 _fn RGBToNormal(float3 rgbval)
 {
     return rgbval * 2.f - 1.f;
 }
@@ -269,7 +269,7 @@ void _fn applyNormalMap(in float3 texValue, _ref(float3) n, _ref(float3) t, _ref
 }
 
 #ifndef _MS_LEAN_MAPPING
-void _fn perturbNormal(in const MaterialData mat, _ref(ShadingAttribs) attr, bool forceSample)
+void _fn perturbNormal(MaterialData mat, _ref(ShadingAttribs) attr, bool forceSample)
 {
 	if(forceSample || mat.desc.hasNormalMap != 0)
 	{
@@ -305,7 +305,7 @@ void applyLeanMap(in Texture2D leanMap, in SamplerState samplerState, inout Shad
     }
 }
 
-void perturbNormal(in const MaterialData mat, inout ShadingAttribs shAttr, bool forceSample)
+void perturbNormal(MaterialData mat, inout ShadingAttribs shAttr, bool forceSample)
 {
     if (mat.desc.hasNormalMap != 0)
     {
@@ -315,7 +315,7 @@ void perturbNormal(in const MaterialData mat, inout ShadingAttribs shAttr, bool 
 #endif
 
 // Note: explicit overload instead of default argument, at least until cross-compiler can handle defaults
-void _fn perturbNormal(in const MaterialData mat, _ref(ShadingAttribs) attr)
+void _fn perturbNormal(MaterialData mat, _ref(ShadingAttribs) attr)
 {
 	perturbNormal(mat, attr, false);
 }
@@ -325,12 +325,12 @@ void _fn perturbNormal(in const MaterialData mat, _ref(ShadingAttribs) attr)
 					Alpha test
 *******************************************************************/
 
-bool _fn alphaTestEnabled(in const MaterialData mat)
+bool _fn alphaTestEnabled(MaterialData mat)
 {
     return mat.desc.hasAlphaMap != 0;
 }
 
-bool _fn alphaTestPassed(in const MaterialData mat, in const ShadingAttribs attr)
+bool _fn alphaTestPassed(MaterialData mat, ShadingAttribs attr)
 {
 #ifndef _MS_DISABLE_ALPHA_TEST
     if(sampleTexture(mat.textures.alphaMap, mat.samplerState, attr).x < mat.values.alphaThreshold)
@@ -339,7 +339,7 @@ bool _fn alphaTestPassed(in const MaterialData mat, in const ShadingAttribs attr
     return true;
 }
 
-void _fn basicAlphaTest(in const MaterialData mat, in const ShadingAttribs attr)
+void _fn basicAlphaTest(MaterialData mat, ShadingAttribs attr)
 {
 #ifndef _MS_DISABLE_ALPHA_TEST
     if(alphaTestEnabled(mat))
@@ -354,7 +354,7 @@ void _fn basicAlphaTest(in const MaterialData mat, in const ShadingAttribs attr)
                     Hashed Alpha Test
 *******************************************************************/
 
-bool _fn hashedAlphaTestPassed(in const MaterialData mat, in const ShadingAttribs attr, float alphaThreshold)
+bool _fn hashedAlphaTestPassed(MaterialData mat, ShadingAttribs attr, float alphaThreshold)
 {
     float compareTo = alphaThreshold <= 0 ? mat.values.alphaThreshold : clamp(alphaThreshold, 0.0f, 1.0f);
 #ifndef _MS_DISABLE_ALPHA_TEST
@@ -364,7 +364,7 @@ bool _fn hashedAlphaTestPassed(in const MaterialData mat, in const ShadingAttrib
     return true;
 }
 
-void _fn applyHashedAlphaTest(in const MaterialData mat, in const ShadingAttribs attr, float alphaThreshold)
+void _fn applyHashedAlphaTest(MaterialData mat, ShadingAttribs attr, float alphaThreshold)
 {
 #ifndef _MS_DISABLE_ALPHA_TEST
     if (alphaTestEnabled(mat))
@@ -454,7 +454,7 @@ float _fn calculateHashedAlpha(float3 hashInputCoord, float hashScale, bool useA
 /*******************************************************************
     alpha test
 *******************************************************************/    
-void _fn applyAlphaTest(in const MaterialData material, in const ShadingAttribs shAttr, float3 posW)
+void _fn applyAlphaTest(MaterialData material, ShadingAttribs shAttr, float3 posW)
 {
     float hashedAlphaScale = 1.0f;
 #ifdef _HASHED_ALPHA_SCALE

--- a/Framework/Source/ShadingUtils/Lights.slang
+++ b/Framework/Source/ShadingUtils/Lights.slang
@@ -60,7 +60,7 @@ struct LightAttribs
 /**
 	This routine computes the position of the the light based on the point 'shadingPosition'.
 */
-inline float3 _fn getLightPos(in const LightData Light, in const float3 shadingPosition)
+inline float3 _fn getLightPos(LightData Light, float3 shadingPosition)
 {
     float3 lightPos = Light.worldPos;
     if(Light.type == LightArea)
@@ -78,7 +78,7 @@ inline float3 _fn getLightPos(in const LightData Light, in const float3 shadingP
 /**
 	This routine computes the radiance from the light at the point 'shadingPosition'.
 */
-inline float3 _fn getLightRadiance(in const LightData Light, in const float3 shadingPosition)
+inline float3 _fn getLightRadiance(LightData Light, float3 shadingPosition)
 {
     float3 lightRadiance = Light.intensity;
     if(Light.type == LightPoint || Light.type == LightArea)
@@ -96,7 +96,7 @@ inline float3 _fn getLightRadiance(in const LightData Light, in const float3 sha
 	The outputs are an incident radiance towards the shading point 
 	and the direction from the shading point towards the light source.
 */
-inline void _fn prepareLightAttribs(in const LightData Light, in const ShadingAttribs ShAttr, float shadowFactor, _ref(LightAttribs) LightAttr)
+inline void _fn prepareLightAttribs(LightData Light, ShadingAttribs ShAttr, float shadowFactor, _ref(LightAttribs) LightAttr)
 {
 	/* Evaluate direction to the light */
     LightAttr.P = getLightPos(Light, ShAttr.P);
@@ -176,7 +176,7 @@ inline void _fn prepareLightAttribs(in const LightData Light, in const ShadingAt
 /**
     This routine samples the light source.
 */
-void _fn sampleLight(in const float3 shadingHitPos, in const LightData lData, const float3 rSample, _ref(LightAttribs) lAttr)
+void _fn sampleLight(float3 shadingHitPos, LightData lData, const float3 rSample, _ref(LightAttribs) lAttr)
 {
 	// Sample the light based on its type: point, directional, or area
 	switch (lData.type)
@@ -281,7 +281,7 @@ void _fn sampleLight(in const float3 shadingHitPos, in const LightData lData, co
 /**
 This routine samples a rectangular area light source in a stratified way.
 */
-void _fn stratifiedSampleRectangularAreaLight(in const float3 shadingHitPos, in const LightData lData, const float2 rSample, int x, int y, int numStrataX, int numStrataY, _ref(LightAttribs) lAttr)
+void _fn stratifiedSampleRectangularAreaLight(float3 shadingHitPos, LightData lData, const float2 rSample, int x, int y, int numStrataX, int numStrataY, _ref(LightAttribs) lAttr)
 {
 	if (lData.type != LightArea)
 		return;

--- a/Framework/Source/ShadingUtils/Shading.slang
+++ b/Framework/Source/ShadingUtils/Shading.slang
@@ -43,7 +43,7 @@ Documentation
 //#define _MS_DISABLE_ALPHA_TEST	///< Disables alpha test (handy for early-z etc.)
 //#define _MS_DISABLE_TEXTURES		///< Disables material texture fetches, all materials are solid color
 //#define _MS_USER_DERIVATIVES		///< Use user-passed dx/dy derivatives for texture filtering during shading
-//#define _MS_USER_NORMAL_MAPPING	///< Use user-defined callback of a form void PerturbNormal(in const SMaterial mat, inout ShadingAttribs ShAttr) to perform normal mapping
+//#define _MS_USER_NORMAL_MAPPING	///< Use user-defined callback of a form void PerturbNormal(SMaterial mat, inout ShadingAttribs ShAttr) to perform normal mapping
 //#define _MS_NUM_LAYERS			///< Use a pre-specified number of layers to use in the material
 //#define _MS_IMPORTANCE_SAMPLING   ///< Use BSDF importance sampling for path tracer next event estimation
 
@@ -118,12 +118,12 @@ This includes fetching all textures and computing final shading attributes, like
 After this step, one can save these shading attributes, e.g., in a G-Buffer to perform lighting afterwards.
 This routine also applies all material modifiers, like performs alpha test and applies a normal map.
 */
-void _fn prepareShadingAttribs(in const MaterialData material, in float3 P, in float3 camPos,
+void _fn prepareShadingAttribs(MaterialData material, in float3 P, in float3 camPos,
     in float3 normal, in float3 bitangent, in float2 uv,
 #ifdef _MS_USER_DERIVATIVES
-    in const float2 dPdx, in const float2 dPdy,
+    float2 dPdx, float2 dPdy,
 #else
-    in const float lodBias,
+    float lodBias,
 #endif
     _ref(ShadingAttribs) shAttr)
 {
@@ -174,12 +174,12 @@ void _fn prepareShadingAttribs(in const MaterialData material, in float3 P, in f
 Another overload of PrepareShadingAttribs(), which does not require tangents.
 Instead it constructs a world-space axis-aligned tangent frame on the fly.
 */
-void _fn prepareShadingAttribs(in const MaterialData material, in float3 P, in float3 camPos,
+void _fn prepareShadingAttribs(MaterialData material, in float3 P, in float3 camPos,
     in float3 normal, in float2 uv,
 #ifdef _MS_USER_DERIVATIVES
-    in const float2 dPdx, in const float2 dPdy,
+    float2 dPdx, float2 dPdy,
 #else
-    in const float lodBias,
+    float lodBias,
 #endif
     _ref(ShadingAttribs) shAttr)
 {
@@ -198,25 +198,25 @@ void _fn prepareShadingAttribs(in const MaterialData material, in float3 P, in f
 
 #ifndef _MS_USER_DERIVATIVES
 // Legacy version of prepareShadingAttribs() without LOD bias
-void _fn prepareShadingAttribs(in const MaterialData material, in float3 P, in float3 camPos, in float3 normal, in float2 uv, _ref(ShadingAttribs) shAttr)
+void _fn prepareShadingAttribs(MaterialData material, in float3 P, in float3 camPos, in float3 normal, in float2 uv, _ref(ShadingAttribs) shAttr)
 {
     prepareShadingAttribs(material, P, camPos, normal, uv, 0, shAttr);
 }
 
-void _fn prepareShadingAttribs(in const MaterialData material, in float3 P, in float3 camPos, in float3 normal, in float3 bitangent, in float2 uv, _ref(ShadingAttribs) shAttr)
+void _fn prepareShadingAttribs(MaterialData material, in float3 P, in float3 camPos, in float3 normal, in float3 bitangent, in float2 uv, _ref(ShadingAttribs) shAttr)
 {
     prepareShadingAttribs(material, P, camPos, normal, bitangent, uv, 0, shAttr);
 }
 #endif
 
-float4 _fn evalEmissiveLayer(in const MaterialLayerValues layer, _ref(PassOutput) result)
+float4 _fn evalEmissiveLayer(MaterialLayerValues layer, _ref(PassOutput) result)
 {
     result.diffuseAlbedo += 1.f;
     result.diffuseIllumination += layer.albedo.rgb;
     return (1).rrrr;
 }
 
-float4 _fn evalDiffuseLayer(in const MaterialLayerValues layer, in const float3 lightIntensity, in const float3 lightDir, in const float3 normal, _ref(PassOutput) result)
+float4 _fn evalDiffuseLayer(MaterialLayerValues layer, float3 lightIntensity, float3 lightDir, float3 normal, _ref(PassOutput) result)
 {
     float3 value = lightIntensity;
     float weight = 0;
@@ -235,7 +235,7 @@ float4 _fn evalDiffuseLayer(in const MaterialLayerValues layer, in const float3 
 
 // Implementation of NDF filtering code from the HPG'16 submission
 // The writeup is here: //research/graphics/projects/halfvectorSpace/SAA/paper/specaa-sub.pdf
-float2 _fn filterRoughness(in const ShadingAttribs shAttr, in const LightAttribs lAttr, in float2 roughness)
+float2 _fn filterRoughness(ShadingAttribs shAttr, LightAttribs lAttr, in float2 roughness)
 {
 #ifdef _MS_USER_HALF_VECTOR_DERIVATIVES
     float2  hppDx = shAttr.DHDX;
@@ -262,7 +262,7 @@ float2 _fn filterRoughness(in const ShadingAttribs shAttr, in const LightAttribs
     return roughness;
 }
 
-float4 _fn evalSpecularLayer(in const MaterialLayerDesc desc, in const MaterialLayerValues data, in const ShadingAttribs shAttr, in const LightAttribs lAttr, _ref(PassOutput) result)
+float4 _fn evalSpecularLayer(MaterialLayerDesc desc, MaterialLayerValues data, ShadingAttribs shAttr, LightAttribs lAttr, _ref(PassOutput) result)
 {
 #ifndef _MS_DISABLE_SPECULAR
     /* Add albedo regardless of facing */
@@ -340,7 +340,7 @@ float4 _fn evalSpecularLayer(in const MaterialLayerDesc desc, in const MaterialL
 #endif
 }
 
-float3 _fn blendLayer(in const float4 albedo, in const float4 layerOut, in const uint blendType, in const float3 currentValue)
+float3 _fn blendLayer(float4 albedo, float4 layerOut, uint blendType, float3 currentValue)
 {
     /* Account for albedo */
     float3 scaledLayerOut = layerOut.rgb * albedo.rgb;
@@ -370,7 +370,7 @@ The routine takes a layer index, as well as shading attributes, including prepar
 it also takes prepared attributes of a light source, such as incident radiance and a world-space direction to the light.
 The output is the illumination of the current layer, blended into the results of the previous layers with a specified blending mode.
 */
-void _fn evalMaterialLayer(in const int iLayer, in const ShadingAttribs attr, in const LightAttribs lAttr,
+void _fn evalMaterialLayer(int iLayer, ShadingAttribs attr, LightAttribs lAttr,
     _ref(PassOutput) result)
 {
     float4 value = 0;
@@ -404,10 +404,10 @@ This is the main routing for evaluating a complete PBR material, given a shading
 Should be called once per light.
 */
 void _fn evalMaterial(
-    in const ShadingAttribs shAttr,
-    in const LightAttribs lAttr,
+    ShadingAttribs shAttr,
+    LightAttribs lAttr,
     _ref(ShadingOutput) result,
-    in const bool initializeShadingOut DEFAULTS(false))
+    bool initializeShadingOut DEFAULTS(false))
 {
     /* If it's the first pass, initialize all the aggregates to zero */
     if(initializeShadingOut)
@@ -449,11 +449,11 @@ void _fn evalMaterial(
 }
 
 void _fn evalMaterial(
-    in const ShadingAttribs shAttr,
-    in const LightData light,
+    ShadingAttribs shAttr,
+    LightData light,
     float shadowFactor,
     _ref(ShadingOutput) result,
-    in const bool initializeShadingOut DEFAULTS(false))
+    bool initializeShadingOut DEFAULTS(false))
 {
     /* Prepare lighting attributes */
     LightAttribs LAttr;
@@ -467,10 +467,10 @@ void _fn evalMaterial(
 Another overload of material evaluation function, which prepares light attributes internally.
 */
 void _fn evalMaterial(
-    in const ShadingAttribs shAttr,
-    in const LightData light,
+    ShadingAttribs shAttr,
+    LightData light,
     _ref(ShadingOutput) result,
-    in const bool initializeShadingOut DEFAULTS(false))
+    bool initializeShadingOut DEFAULTS(false))
 {
     evalMaterial(shAttr, light, 1, result, initializeShadingOut);
 }
@@ -493,7 +493,7 @@ void _fn initNullLayer(_ref(MaterialLayerDesc) layer)
 /**
 Initializes a material layer with diffuse BRDF
 */
-void _fn initDiffuseLayer(_ref(MaterialLayerDesc) desc, _ref(MaterialLayerValues) data, in const float3 albedo)
+void _fn initDiffuseLayer(_ref(MaterialLayerDesc) desc, _ref(MaterialLayerValues) data, float3 albedo)
 {
     desc.type = MatLambert;
     desc.blending = BlendAdd;
@@ -509,7 +509,7 @@ void _fn initDiffuseLayer(_ref(MaterialLayerDesc) desc, _ref(MaterialLayerValues
 /**
 Initializes a material layer with conductor BRDF. IoR and Kappa are set to the values of chrome by default.
 */
-void _fn initConductorLayer(_ref(MaterialLayerDesc) desc, _ref(MaterialLayerValues) data, in const float3 color, in const float roughness, in const float IoR = 3.f, in const float kappa = 4.2f)
+void _fn initConductorLayer(_ref(MaterialLayerDesc) desc, _ref(MaterialLayerValues) data, float3 color, float roughness, float IoR = 3.f, float kappa = 4.2f)
 {
     desc.type = MatConductor;
     desc.blending = BlendAdd;
@@ -523,7 +523,7 @@ void _fn initConductorLayer(_ref(MaterialLayerDesc) desc, _ref(MaterialLayerValu
 /**
 Initializes a material layer with dielectric BRDF.
 */
-void _fn initDielectricLayer(_ref(MaterialLayerDesc) desc, _ref(MaterialLayerValues) data, in const float3 color, in const float roughness, in const float IoR)
+void _fn initDielectricLayer(_ref(MaterialLayerDesc) desc, _ref(MaterialLayerValues) data, float3 color, float roughness, float IoR)
 {
     desc.type = MatDielectric;
     desc.blending = BlendFresnel;
@@ -544,7 +544,7 @@ Tries to find a layer data for a given material type (diffuse/conductor/etc).
 \param[out] data           Layer data, if found
 returns false if the layer is not found, true otherwise
 */
-bool _fn getLayerByType(in const PreparedMaterialData material, in const uint layerType, _ref(MaterialLayerValues) data, _ref(MaterialLayerDesc) desc)
+bool _fn getLayerByType(PreparedMaterialData material, uint layerType, _ref(MaterialLayerValues) data, _ref(MaterialLayerDesc) desc)
 {
     int layerId = material.desc.layerIdByType[layerType].id;
     if(layerId != -1)
@@ -561,7 +561,7 @@ Tries to find a diffuse albedo color for a given material
 \param[in] Material Material to look in
 returns black if the layer is not found, diffuse albedo color otherwise
 */
-float4 _fn getDiffuseColor(in const ShadingAttribs shAttr)
+float4 _fn getDiffuseColor(ShadingAttribs shAttr)
 {
     float4 ret = 0;
     // This is here because the HLSL compiler complains about 'data' not being completely initialized when used
@@ -614,7 +614,7 @@ Tries to find a specular albedo color for a given material
 \param[in] material Material to look in
 returns black if the layer is not found, specular color otherwise
 */
-float4 _fn getSpecularColor(in const ShadingAttribs shAttr)
+float4 _fn getSpecularColor(ShadingAttribs shAttr)
 {
     float4 ret = 0;
     MaterialLayerValues data;
@@ -635,7 +635,7 @@ float4 _fn getSpecularColor(in const ShadingAttribs shAttr)
     \param[out] result Gather incident direction, probability density function, and path throughput
 */
 void _fn sampleMaterial(
-	in const ShadingAttribs shAttr,
+	ShadingAttribs shAttr,
 	in float2 rSample,
 	_ref(ShadingOutput) result)
 {


### PR DESCRIPTION
The root cause here is the interaction of two bad choices:

1. The Falcor shader library has a bit of a fetish for marking things (including shader parameters) as `const` whenever possible

2. The Slang compiler currently isn't smart enough to know the difference between GLSL `const` and HLSL `const`

This meant that we passed through GLSL code that declared a bunch of things `const` that didn't need to be declared that way. GLSL has historically had a very stringent idea of what `const` means, and while it seems that the current language spec is more lax, it may be the case that some drivers get confused by our code applying `const` to things that are not compile-time constants.

For now, I'm proposing to fix this by banning `const` on parameters from the Falcor shader library. A better long-term fix is for Slang to not pass through HLSL/Slang `const` directly to GLSL.