### PR TITLE
Remove more `const` qualifiers from Slang code

### DIFF
--- a/Framework/Source/Data/Effects/CascadedShadowMap.slang
+++ b/Framework/Source/Data/Effects/CascadedShadowMap.slang
@@ -30,7 +30,7 @@
 
 SamplerComparisonState gCsmCompareSampler;
 
-int getCascadeCount(const CsmData csmData)
+int getCascadeCount(CsmData csmData)
 {
 #ifdef _CSM_CASCADE_COUNT
     return _CSM_CASCADE_COUNT;
@@ -39,7 +39,7 @@ int getCascadeCount(const CsmData csmData)
 #endif
 }
 
-uint32_t getFilterMode(const CsmData csmData)
+uint32_t getFilterMode(CsmData csmData)
 {
 #ifdef _CSM_FILTER_MODE
     return _CSM_FILTER_MODE;
@@ -48,7 +48,7 @@ uint32_t getFilterMode(const CsmData csmData)
 #endif
 }
 
-int getCascadeIndex(const CsmData csmData, float depthCamClipSpace)
+int getCascadeIndex(CsmData csmData, float depthCamClipSpace)
 {
     for(int i = 1; i < getCascadeCount(csmData); i++)
     {
@@ -85,7 +85,7 @@ float3 getCascadeColor(uint32_t cascade)
     }
 }
 #if 0
-float calcReceiverPlaneDepthBias(const CsmData csmData, const float3 shadowPos)
+float calcReceiverPlaneDepthBias(CsmData csmData, float3 shadowPos)
 {
     float3 posDX = dFdxFine(shadowPos);
     float3 posDY = dFdyFine(shadowPos);
@@ -106,7 +106,7 @@ float calcReceiverPlaneDepthBias(const CsmData csmData, const float3 shadowPos)
     return min(bias, csmData.maxReceiverPlaneDepthBias);
 }
 
-float3 calcNormalOffset(const CsmData csmData, float3 normal, uint32_t cascadeIndex)
+float3 calcNormalOffset(CsmData csmData, float3 normal, uint32_t cascadeIndex)
 {
     // Need to move more when ndotl == 0
     float3 N = normalize(normal);
@@ -127,13 +127,13 @@ float2 applyEvsmExponents(float depth, float2 exponents)
     return expDepth;
 }
 
-float csmFilterUsingHW(const CsmData csmData, const float2 texC, float depthRef, uint32_t cascadeIndex)
+float csmFilterUsingHW(CsmData csmData, float2 texC, float depthRef, uint32_t cascadeIndex)
 {
     float res = csmData.shadowMap.SampleCmpLevelZero(gCsmCompareSampler, float3(texC, cascadeIndex), depthRef).r;
     return saturate(res);
 }
 
-float csmFixedSizePcf(const CsmData csmData, const float2 texC, float depthRef, uint32_t cascadeIndex)
+float csmFixedSizePcf(CsmData csmData, float2 texC, float depthRef, uint32_t cascadeIndex)
 {
     float3 dim;
     csmData.shadowMap.GetDimensions(dim.x, dim.y, dim.z);
@@ -153,7 +153,7 @@ float csmFixedSizePcf(const CsmData csmData, const float2 texC, float depthRef, 
     return res / (csmData.pcfKernelWidth * csmData.pcfKernelWidth);
 }
 
-float csmStochasticFilter(const CsmData csmData, const float2 texC, float depthRef, uint32_t cascadeIndex, float2 posSxy)
+float csmStochasticFilter(CsmData csmData, float2 texC, float depthRef, uint32_t cascadeIndex, float2 posSxy)
 {
     float3 dim;
     csmData.shadowMap.GetDimensions(dim.x, dim.y, dim.z);
@@ -211,7 +211,7 @@ float calcChebyshevUpperBound(float2 moments, float depth, float lightBleedingRe
     return res;
 }
 
-float csmVsmFilter(const CsmData csmData, const float2 texC, float sampleDepth, uint32_t cascadeIndex, bool calcDrv, inout float2 drvX, inout float2 drvY)
+float csmVsmFilter(CsmData csmData, float2 texC, float sampleDepth, uint32_t cascadeIndex, bool calcDrv, inout float2 drvX, inout float2 drvY)
 {
     if(calcDrv)
     {
@@ -224,7 +224,7 @@ float csmVsmFilter(const CsmData csmData, const float2 texC, float sampleDepth, 
     return pMax;
 }
 
-float csmEvsmFilter(const CsmData csmData, const float2 texC, float sampleDepth, uint32_t cascadeIndex, bool calcDrv, inout float2 drvX, inout float2 drvY)
+float csmEvsmFilter(CsmData csmData, float2 texC, float sampleDepth, uint32_t cascadeIndex, bool calcDrv, inout float2 drvX, inout float2 drvY)
 {
     if(calcDrv)
     {

--- a/Framework/Source/Data/Effects/TAA.ps.slang
+++ b/Framework/Source/Data/Effects/TAA.ps.slang
@@ -61,8 +61,8 @@ float4 main(float2 texC : TEXCOORD) : SV_TARGET0
     uint levels;
     gTexColor.GetDimensions(0, texDim.x, texDim.y, levels);
 
-    const float2 pos = texC * texDim;
-    const int2 ipos = int2(pos);
+    float2 pos = texC * texDim;
+    int2 ipos = int2(pos);
 
     // Fetch the current pixel color and compute the color bounding box
     // Details here: http://www.gdcvault.com/play/1023521/From-the-Lab-Bench-Real
@@ -80,11 +80,11 @@ float4 main(float2 texC : TEXCOORD) : SV_TARGET0
         colorVar += c * c;
     }
 
-    const float oneOverNine = 1.0 / 9.0;
+    float oneOverNine = 1.0 / 9.0;
     colorAvg *= oneOverNine;
     colorVar *= oneOverNine;
 
-    const float3 sigma = sqrt(max(0.0f, colorVar - colorAvg * colorAvg));
+    float3 sigma = sqrt(max(0.0f, colorVar - colorAvg * colorAvg));
     float3 colorMin = colorAvg - gColorBoxSigma * sigma;
     float3 colorMax = colorAvg + gColorBoxSigma * sigma;    
 
@@ -93,7 +93,7 @@ float4 main(float2 texC : TEXCOORD) : SV_TARGET0
     [unroll]
     for (int a = 0; a < 8; a++) 
     {
-        const float2 m = gTexMotionVec.Load(int3(ipos + offset[a], 0)).rg;
+        float2 m = gTexMotionVec.Load(int3(ipos + offset[a], 0)).rg;
         motion = dot(m, m) > dot(motion, motion) ? m : motion;   
     }
 

--- a/Framework/Source/ShadingUtils/BSDFs.slang
+++ b/Framework/Source/ShadingUtils/BSDFs.slang
@@ -49,8 +49,8 @@ Schlick's approximation for reflection of a dielectric media
 float _fn dielectricFresnelSchlick(float VdH, float IoR)
 {
     float R0 = (1.f - IoR) / (1.f + IoR);	R0 *= R0;
-    const float OneMinusCos = 1.f - VdH;
-    const float OneMinusCos2 = OneMinusCos*OneMinusCos;
+    float OneMinusCos = 1.f - VdH;
+    float OneMinusCos2 = OneMinusCos*OneMinusCos;
     return R0 + (1.f - R0) * OneMinusCos*OneMinusCos2*OneMinusCos2;	// to the power of 5
 }
 
@@ -60,8 +60,8 @@ between two dielectrics
 */
 float _fn dielectricFresnelFast(float NdE, float NdL, float IoR)
 {
-    const float Rs = (NdE - IoR * NdL) / (NdE + IoR * NdL);	// Transmitted-to-incident wave ratio, perpendicular component
-    const float Rp = (IoR * NdE - NdL) / (IoR * NdE + NdL);	// Transmitted-to-incident wave ratio, parallel component
+    float Rs = (NdE - IoR * NdL) / (NdE + IoR * NdL);	// Transmitted-to-incident wave ratio, perpendicular component
+    float Rp = (IoR * NdE - NdL) / (IoR * NdE + NdL);	// Transmitted-to-incident wave ratio, parallel component
     return (Rs * Rs + Rp * Rp) * .5f;						// Total amplitude of the transmitted wave
 }
 
@@ -71,15 +71,15 @@ between two dielectrics
 */
 float _fn dielectricFresnel(in float NdE, float IoR)
 {
-    const float realIoR = (NdE >= 0.f) ? 1.f / IoR : IoR;
+    float realIoR = (NdE >= 0.f) ? 1.f / IoR : IoR;
     // Perform a refraction
-    const float NdL2 = 1.f - realIoR * realIoR * (1.f - NdE * NdE);
+    float NdL2 = 1.f - realIoR * realIoR * (1.f - NdE * NdE);
     if(NdL2 <= 0.f)	// Total internal reflection case
         return 1.f;
-    const float NdL = sqrt(NdL2);
+    float NdL = sqrt(NdL2);
     NdE = abs(NdE);		// Wrap the incident direction
-    const float Rp = (IoR * NdL - NdE) / (IoR * NdL + NdE);	// Reflected-to-incident wave ratio, parallel component
-    const float Rs = (NdE - IoR * NdL) / (NdE + IoR * NdL);	// Reflected-to-incident wave ratio, parallel component
+    float Rp = (IoR * NdL - NdE) / (IoR * NdL + NdE);	// Reflected-to-incident wave ratio, parallel component
+    float Rs = (NdE - IoR * NdL) / (NdE + IoR * NdL);	// Reflected-to-incident wave ratio, parallel component
     return (Rp * Rp + Rs * Rs) * .5f;						// Total amplitude of the reflected wave
 }
 
@@ -89,13 +89,13 @@ between a dielectric (usually air) and a conductive media
 */
 float _fn conductorFresnel(in float NdE, float IoR, float Kappa)
 {
-    const float Kappa2 = Kappa * Kappa;
-    const float TotalIoR2 = IoR * IoR + Kappa2;	// Total magnitude of IoR: Real plus complex parts of IoR
+    float Kappa2 = Kappa * Kappa;
+    float TotalIoR2 = IoR * IoR + Kappa2;	// Total magnitude of IoR: Real plus complex parts of IoR
     NdE = saturate(NdE);			// No refraction allowed
-    const float NdE2 = NdE * NdE;
-    const float ReducedNdE2 = TotalIoR2 * NdE2;
-    const float Rp2 = (ReducedNdE2 - IoR * NdE * 2.f + 1.f) / (ReducedNdE2 + IoR * NdE * 2.f + 1.f);	// Reflected-to-incident wave ratio, perpendicular component
-    const float Rs2 = (TotalIoR2 - IoR * NdE * 2.f + NdE2) / (TotalIoR2 + IoR * NdE * 2.f + NdE2);		// Reflected-to-incident wave ratio, parallel component
+    float NdE2 = NdE * NdE;
+    float ReducedNdE2 = TotalIoR2 * NdE2;
+    float Rp2 = (ReducedNdE2 - IoR * NdE * 2.f + 1.f) / (ReducedNdE2 + IoR * NdE * 2.f + 1.f);	// Reflected-to-incident wave ratio, perpendicular component
+    float Rs2 = (TotalIoR2 - IoR * NdE * 2.f + NdE2) / (TotalIoR2 + IoR * NdE * 2.f + NdE2);		// Reflected-to-incident wave ratio, parallel component
     return (Rp2 + Rs2) * .5f;					// Total amplitude of the reflected wave
 }
 
@@ -116,10 +116,10 @@ Blinn-Phong normal distribution function (NDF).
 */
 float _fn evalPhongDistribution(in float3 N, in float3 V, in float3 L, in float roughness)
 {
-    const float spec_power = convertRoughnessToShininess(roughness);
-    const float3 H = normalize(L + V);
-    const float NoH = max(0.f, dot(N, H));
-    const float normalization = (spec_power + 2.f) / (2.f * M_PIf);
+    float spec_power = convertRoughnessToShininess(roughness);
+    float3 H = normalize(L + V);
+    float NoH = max(0.f, dot(N, H));
+    float normalization = (spec_power + 2.f) / (2.f * M_PIf);
     return pow(NoH, spec_power) * normalization;
 }
 
@@ -128,21 +128,21 @@ Beckmann normal distribution function (NDF).
 */
 float _fn evalBeckmannDistribution(float3 N, float3 H, in float roughness)
 {
-    const float a2 = roughness * roughness;
+    float a2 = roughness * roughness;
     // dot products that we need
-    const float NoH = dot(N, H);
-    const float NoH2 = NoH * NoH;
+    float NoH = dot(N, H);
+    float NoH2 = NoH * NoH;
     // Compute Beckmann distribution
-    const float exponent = max(0.f, (1.f - NoH2) / (a2 * NoH2));
+    float exponent = max(0.f, (1.f - NoH2) / (a2 * NoH2));
     return exp(-exponent) / (M_PIf * a2 * NoH2 * NoH2);
 }
 
 float _fn evalBeckmannDistribution(float3 H, float2 rgns)
 {
-    const float NoH2 = H.z * H.z;
-    const float2 Hproj = float2(H.x, H.y);
+    float NoH2 = H.z * H.z;
+    float2 Hproj = float2(H.x, H.y);
     // Compute Beckmann distribution
-    const float exponent = dot(Hproj / (rgns*rgns), Hproj) / NoH2;
+    float exponent = dot(Hproj / (rgns*rgns), Hproj) / NoH2;
     return exp(-exponent) / (M_PIf * rgns.x * rgns.y * NoH2 * NoH2);
 }
 
@@ -165,8 +165,8 @@ This approximation works fine for G smith correlated and uncorrelated
 float3 _fn getBeckmannDominantDir(float3 N, float3 R,
     float roughness)
 {
-    const float smoothness = clamp(1.f - roughness, 0.0f, 1.0f);
-    const float lerpFactor = smoothness * (sqrt(smoothness) + roughness);
+    float smoothness = clamp(1.f - roughness, 0.0f, 1.0f);
+    float lerpFactor = smoothness * (sqrt(smoothness) + roughness);
     // The result is not normalized as we fetch in a cubemap
     return lerp(N, R, lerpFactor);
 }
@@ -178,9 +178,9 @@ GGX normal distribution function (NDF).
 float _fn evalGGXDistribution(float3 N, float3 H, float roughness)
 {
     // This doesn't look correct, so disabled    
-    const float a2 = roughness * roughness;
+    float a2 = roughness * roughness;
     // dot products that we need
-    const float NoH = saturate(dot(N, H));
+    float NoH = saturate(dot(N, H));
     // D term
     float D_denom = (NoH * a2 - NoH) * NoH + 1.0f;
     D_denom = M_PIf * D_denom * D_denom;
@@ -190,13 +190,13 @@ float _fn evalGGXDistribution(float3 N, float3 H, float roughness)
 float _fn evalGGXDistribution(float3 H, float2 rgns)
 {
     // Numerically robust (w.r.t rgns=0) implementation of anisotropic GGX
-    const float anisoU = rgns.y < rgns.x ? rgns.y / rgns.x : 1.f;
-    const float anisoV = rgns.x < rgns.y ? rgns.x / rgns.y : 1.f;
-    const float r = min(rgns.x, rgns.y);
-    const float NoH2 = H.z * H.z;
-    const float2 Hproj = float2(H.x, H.y);
-    const float exponent = dot(Hproj / float2(anisoU*anisoU, anisoV*anisoV), Hproj);
-    const float root = NoH2 * r*r + exponent;
+    float anisoU = rgns.y < rgns.x ? rgns.y / rgns.x : 1.f;
+    float anisoV = rgns.x < rgns.y ? rgns.x / rgns.y : 1.f;
+    float r = min(rgns.x, rgns.y);
+    float NoH2 = H.z * H.z;
+    float2 Hproj = float2(H.x, H.y);
+    float exponent = dot(Hproj / float2(anisoU*anisoU, anisoV*anisoV), Hproj);
+    float root = NoH2 * r*r + exponent;
     return r*r / (M_PIf * anisoU * anisoV * root * root);
 }
 
@@ -210,12 +210,12 @@ Computes the intermediate effective microfacet roughness observed from a particu
 \param[in] rghns original anisotropic roughness of the microfacet BSDF
 returns effective visible roughness
 */
-float _fn effectiveVisibleRoughness(const in float3 dir, const in float2 rghns)
+float _fn effectiveVisibleRoughness(float3 dir, float2 rghns)
 {
-    const float recipSinThSq = 1.f / (1.f - dir.z * dir.z);
-    const float2 dirPlane = float2(dir.x, dir.y);
-    const float2 cosSinPhiSq = dirPlane * dirPlane * recipSinThSq;
-    const float2 res = rghns * rghns * cosSinPhiSq;
+    float recipSinThSq = 1.f / (1.f - dir.z * dir.z);
+    float2 dirPlane = float2(dir.x, dir.y);
+    float2 cosSinPhiSq = dirPlane * dirPlane * recipSinThSq;
+    float2 res = rghns * rghns * cosSinPhiSq;
     return sqrt(res.x + res.y);
 }
 
@@ -227,27 +227,27 @@ Computes the Smith'67 shadowing or masking term from a direction.
 \param[in] ndfType type of NDF. Only Beckmann and GGX are supported so far
 returns amount of visible microfacets
 */
-float _fn GSmith(const in float3 dir, const in float3 h, const in float2 rghns, uint ndfType)
+float _fn GSmith(float3 dir, float3 h, float2 rghns, uint ndfType)
 {
     if(dot(dir, h) * dir.z <= 0.f)
         return 0.f;
-    const float sinThSq = 1.f - dir.z * dir.z;
+    float sinThSq = 1.f - dir.z * dir.z;
     if(sinThSq <= 0.f)
         return 1.f;
-    const float recipSlope = sqrt(sinThSq) / dir.z;
-    const float alpha = effectiveVisibleRoughness(dir, rghns);
+    float recipSlope = sqrt(sinThSq) / dir.z;
+    float alpha = effectiveVisibleRoughness(dir, rghns);
     if(ndfType == NDFBeckmann)
     {
         // Use the Beckmann G fit from [Walter07]
-        const float a = 1.f / (alpha * recipSlope);
+        float a = 1.f / (alpha * recipSlope);
         if(a > 1.6f)
             return 1.f;
-        const float aSq = a*a;
+        float aSq = a*a;
         return (3.535f * a + 2.181f * aSq) / (1.f + 2.276f * a + 2.577f * aSq);
     }
 
     // Otherwise it's GGX, use GGX shadowing/masking
-    const float isectRoot = alpha * recipSlope;
+    float isectRoot = alpha * recipSlope;
     return 2.f / (1.f + length(float2(1.f, isectRoot)));
 }
 
@@ -258,8 +258,8 @@ float _fn evalMicrofacetTerms(float3 T, float3 B, float3 N,
     float3 h, float3 V, float3 L,
     float2 roughness, uint ndfType, bool transmissive)
 {
-    const float3 lTg = float3(dot(T, L), dot(B, L), dot(N, L));
-    const float3 vTg = float3(dot(T, V), dot(B, V), dot(N, V));
+    float3 lTg = float3(dot(T, L), dot(B, L), dot(N, L));
+    float3 vTg = float3(dot(T, V), dot(B, V), dot(N, V));
 
     /* If it's not transmission, they should be on the same side of the hemisphere */
     if(!transmissive && lTg.z*vTg.z <= 0.f)
@@ -349,7 +349,7 @@ float _fn sampleGGXDistribution(
 {
 	float alphaSqr = roughness.x * roughness.x;
 
-    const bool perfectSpecular = alphaSqr <= 1e-6f;
+    bool perfectSpecular = alphaSqr <= 1e-6f;
 
     if(perfectSpecular)
     {

--- a/Framework/Source/ShadingUtils/Helpers.slang
+++ b/Framework/Source/ShadingUtils/Helpers.slang
@@ -43,8 +43,8 @@ static const float M_1_PIf = 0.31830988618379f;
 _fn float2 sample_disk(float rnd1, float rnd2, float minRSq = 0.0f)
 {
     float2 p;
-    const float r = sqrt(max(minRSq, rnd1));
-    const float phi = 2.0f * M_PIf * rnd2;
+    float r = sqrt(max(minRSq, rnd1));
+    float phi = 2.0f * M_PIf * rnd2;
     p.x = r * cos(phi);
     p.y = r * sin(phi);
     return p;
@@ -53,8 +53,8 @@ _fn float2 sample_disk(float rnd1, float rnd2, float minRSq = 0.0f)
 _fn float3 sample_gauss(float rnd1, float rnd2)
 {
     float3 p;
-    const float r = sqrt(-2.f * log(1.f - rnd1));
-    const float phi = 2.0f * M_PIf * rnd2;
+    float r = sqrt(-2.f * log(1.f - rnd1));
+    float phi = 2.0f * M_PIf * rnd2;
     p.x = r * cos(phi);
     p.y = r * sin(phi);
     p.z = 0.0f;
@@ -109,8 +109,8 @@ _fn float3 uniform_sample_sphere(float rnd1, float rnd2)
 {
     float3 p;
     p.z = 2.0f * rnd1 - 1.0f;
-    const float r = sqrt(max(0.0f, 1.0f - p.z * p.z));
-    const float phi = 2.0f * M_PIf * rnd2;
+    float r = sqrt(max(0.0f, 1.0f - p.z * p.z));
+    float phi = 2.0f * M_PIf * rnd2;
     p.x = r * cos(phi);
     p.y = r * sin(phi);
     return p;
@@ -120,8 +120,8 @@ _fn float3 uniform_sample_hemisphere(float rnd1, float rnd2)
 {
     float3 p;
     p.z = rnd1;
-    const float r = sqrt(max(0.0f, 1.0f - p.z * p.z));
-    const float phi = 2.0f * M_PIf * rnd2;
+    float r = sqrt(max(0.0f, 1.0f - p.z * p.z));
+    float phi = 2.0f * M_PIf * rnd2;
     p.x = r * cos(phi);
     p.y = r * sin(phi);
     return p;
@@ -147,8 +147,8 @@ _fn uint rand_init(uint val0, uint val1, uint backoff = 16)
 
 _fn float rand_next(_ref(uint) s)
 {
-    const uint LCG_A = 1664525u;
-    const uint LCG_C = 1013904223u;
+    uint LCG_A = 1664525u;
+    uint LCG_C = 1013904223u;
     s = (LCG_A * s + LCG_C);
     return float(s & 0x00FFFFFF) / float(0x01000000);
 }
@@ -158,7 +158,7 @@ _fn float rand_next(_ref(uint) s)
 *******************************************************************/
 
 // Ideal specular refraction
-_fn float3 refract(const float3 I, const float3 N, float eta)
+_fn float3 refract(float3 I, float3 N, float eta)
 {
     float dNI = dot(N, I);
     float k = 1.0f - eta * eta * (1.0f - dNI * dNI);
@@ -198,7 +198,7 @@ void _fn reflectFrame(float3 n, float3 reflect, _ref(float3) t, _ref(float3) b)
 					Texturing routines
 *******************************************************************/
 
-float4 _fn sampleTexture(Texture2D t, SamplerState s, const ShadingAttribs attr)
+float4 _fn sampleTexture(Texture2D t, SamplerState s, ShadingAttribs attr)
 {
 #ifndef _MS_USER_DERIVATIVES
     return t.SampleBias(s, attr.UV, attr.lodBias);
@@ -208,7 +208,7 @@ float4 _fn sampleTexture(Texture2D t, SamplerState s, const ShadingAttribs attr)
 }
 
 #ifndef CUDA_CODE
-float4 _fn sampleTexture(Texture2DArray t, SamplerState s, const ShadingAttribs attr, int arrayIndex)
+float4 _fn sampleTexture(Texture2DArray t, SamplerState s, ShadingAttribs attr, int arrayIndex)
 {
 #ifndef _MS_USER_DERIVATIVES
     return t.SampleBias(s, float3(attr.UV, arrayIndex), attr.lodBias);
@@ -261,7 +261,7 @@ float3 _fn toLocal(in float3 v, in float3 t, in float3 b, in float3 n)
 
 void _fn applyNormalMap(in float3 texValue, _ref(float3) n, _ref(float3) t, _ref(float3) b)
 {
-	const float3 normalMap = normalize(texValue);
+	float3 normalMap = normalize(texValue);
 	n = fromLocal(normalMap, normalize(t), normalize(b), normalize(n));
     // Orthogonalize tangent frame
     b = normalize(b - n * dot(b, n));

--- a/Framework/Source/ShadingUtils/Lights.slang
+++ b/Framework/Source/ShadingUtils/Lights.slang
@@ -128,7 +128,7 @@ inline void _fn prepareLightAttribs(LightData Light, ShadingAttribs ShAttr, floa
 		/* Evaluate various attenuation factors: cosine, 1/r^2, etc. */
 		float Atten = 1.f;
 
-		const float cosTheta = -dot(LightAttr.L, Light.worldDir);	// cos of angle of light orientation with outgoing direction
+		float cosTheta = -dot(LightAttr.L, Light.worldDir);	// cos of angle of light orientation with outgoing direction
         if(Light.type == LightArea)			// Cosine attenuation
         {
 			Atten = max(0.f, cosTheta) * Light.surfaceArea;
@@ -176,7 +176,7 @@ inline void _fn prepareLightAttribs(LightData Light, ShadingAttribs ShAttr, floa
 /**
     This routine samples the light source.
 */
-void _fn sampleLight(float3 shadingHitPos, LightData lData, const float3 rSample, _ref(LightAttribs) lAttr)
+void _fn sampleLight(float3 shadingHitPos, LightData lData, float3 rSample, _ref(LightAttribs) lAttr)
 {
 	// Sample the light based on its type: point, directional, or area
 	switch (lData.type)
@@ -228,7 +228,7 @@ void _fn sampleLight(float3 shadingHitPos, LightData lData, const float3 rSample
 				optix::bufferId<int3, 1> indices(lData.indexPtr.ptr);
 				optix::bufferId<float3, 1> vertices(lData.vertexPtr.ptr);
 				// Retrieve indices
-				const int3 pId = indices[index];
+				int3 pId = indices[index];
 				// Get vertices pointed by the corresponding index
 				float3 p0 = vertices[pId.x];
 				float3 p1 = vertices[pId.y];
@@ -237,7 +237,7 @@ void _fn sampleLight(float3 shadingHitPos, LightData lData, const float3 rSample
 				int* indices = (int*)(lData.indexPtr.ptr);
 				float* vertices = (float*)(lData.vertexPtr.ptr);
 				// Retrieve indices
-				const int3 pId = int3(indices[index * 3 + 0], indices[index * 3 + 1], indices[index * 3 + 2]);
+				int3 pId = int3(indices[index * 3 + 0], indices[index * 3 + 1], indices[index * 3 + 2]);
 				// Get vertices pointed by the corresponding index
 				float3 p0 = float3(vertices[pId.x * 3 + 0], vertices[pId.x * 3 + 1], vertices[pId.x * 3 + 2]);
 				float3 p1 = float3(vertices[pId.y * 3 + 0], vertices[pId.y * 3 + 1], vertices[pId.y * 3 + 2]);
@@ -251,7 +251,7 @@ void _fn sampleLight(float3 shadingHitPos, LightData lData, const float3 rSample
 
 				// Sample a point on the triangle mesh using barycentric coordinates
 				float a = sqrt(rSample.x);
-				const float2 bary = float2(1.f - a, a * rSample.y);
+				float2 bary = float2(1.f - a, a * rSample.y);
 
 				lAttr.P = p0 * bary.x + p1 * bary.y + p2 * (1.f - bary.x - bary.y);
 
@@ -281,7 +281,7 @@ void _fn sampleLight(float3 shadingHitPos, LightData lData, const float3 rSample
 /**
 This routine samples a rectangular area light source in a stratified way.
 */
-void _fn stratifiedSampleRectangularAreaLight(float3 shadingHitPos, LightData lData, const float2 rSample, int x, int y, int numStrataX, int numStrataY, _ref(LightAttribs) lAttr)
+void _fn stratifiedSampleRectangularAreaLight(float3 shadingHitPos, LightData lData, float2 rSample, int x, int y, int numStrataX, int numStrataY, _ref(LightAttribs) lAttr)
 {
 	if (lData.type != LightArea)
 		return;

--- a/Framework/Source/ShadingUtils/Shading.slang
+++ b/Framework/Source/ShadingUtils/Shading.slang
@@ -144,9 +144,9 @@ void _fn prepareShadingAttribs(MaterialData material, in float3 P, in float3 cam
 
     /* Copy the input material parameters */
 #ifdef _MS_STATIC_MATERIAL_DESC
-    const MaterialDesc desc = _MS_STATIC_MATERIAL_DESC;
+    MaterialDesc desc = _MS_STATIC_MATERIAL_DESC;
 #else
-    const MaterialDesc desc = material.desc;
+    MaterialDesc desc = material.desc;
 #endif
 
     shAttr.preparedMat.values = material.values;
@@ -299,8 +299,8 @@ float4 _fn evalSpecularLayer(MaterialLayerDesc desc, MaterialLayerValues data, S
     }
     
     // compute halfway vector
-    const float3 hW = normalize(shAttr.E + lAttr.L);
-    const float3 h = normalize(float3(dot(hW, shAttr.T), dot(hW, shAttr.B), dot(hW, shAttr.N)));
+    float3 hW = normalize(shAttr.E + lAttr.L);
+    float3 h = normalize(float3(dot(hW, shAttr.T), dot(hW, shAttr.B), dot(hW, shAttr.N)));
 
     result.roughness = roughness;
 
@@ -325,10 +325,10 @@ float4 _fn evalSpecularLayer(MaterialLayerDesc desc, MaterialLayerValues data, S
     value /= 4.f * dot(shAttr.E, shAttr.N);
 
     /* Fresnel conductor/dielectric term */
-    const float HoE = dot(hW, shAttr.E);
-    const float IoR = data.extraParam.x;
-    const float kappa = data.extraParam.y;
-    const float F_term = (desc.type == MatConductor) ? conductorFresnel(HoE, IoR, kappa) : 1.f - dielectricFresnel(HoE, IoR);
+    float HoE = dot(hW, shAttr.E);
+    float IoR = data.extraParam.x;
+    float kappa = data.extraParam.y;
+    float F_term = (desc.type == MatConductor) ? conductorFresnel(HoE, IoR, kappa) : 1.f - dielectricFresnel(HoE, IoR);
     value *= F_term;
     float weight = F_term;
 
@@ -375,8 +375,8 @@ void _fn evalMaterialLayer(int iLayer, ShadingAttribs attr, LightAttribs lAttr,
 {
     float4 value = 0;
 
-    const MaterialLayerValues values = attr.preparedMat.values.layers[iLayer];
-    const MaterialLayerDesc desc = attr.preparedMat.desc.layers[iLayer];
+    MaterialLayerValues values = attr.preparedMat.values.layers[iLayer];
+    MaterialLayerDesc desc = attr.preparedMat.desc.layers[iLayer];
     switch(desc.type)
     {
     case MatLambert: /* Diffuse BRDF */
@@ -581,7 +581,7 @@ Tries to override a diffuse albedo color for all layers within a given material
 \param[in] Material Material to look in
 returns true if succeeded
 */
-bool _fn overrideDiffuseColor(_ref(ShadingAttribs) shAttr, const float4 albedo, const bool allLayers = true)
+bool _fn overrideDiffuseColor(_ref(ShadingAttribs) shAttr, float4 albedo, bool allLayers = true)
 {
     bool found = false;
     if(!allLayers)
@@ -660,8 +660,8 @@ void _fn sampleMaterial(
 			sampleDiffuse = false;
 
 			float3 m;
-			const float3 wo = toLocal(shAttr.E, shAttr.T, shAttr.B, shAttr.N);
-			const float2 roughness = float2(specData.roughness.x, specData.roughness.y);
+			float3 wo = toLocal(shAttr.E, shAttr.T, shAttr.B, shAttr.N);
+			float2 roughness = float2(specData.roughness.x, specData.roughness.y);
 
 			// Set the specular reflectivity
 			result.specularAlbedo = specData.albedo.rgb;
@@ -691,10 +691,10 @@ void _fn sampleMaterial(
             result.thp *= evalMicrofacetTerms(shAttr.T, shAttr.B, shAttr.N, m, shAttr.E, result.wi, roughness, specDesc.ndf, (specDesc.type) == MatDielectric);
 
 			// Fresnel conductor/dielectric term
-			const float HoE = dot(m, shAttr.E);
-			const float IoR = specData.extraParam.x;
-			const float kappa = specData.extraParam.y;
-            const float F_term = (specDesc.type == MatConductor) ? conductorFresnel(HoE, IoR, kappa) : 1.f - dielectricFresnel(HoE, IoR);
+			float HoE = dot(m, shAttr.E);
+			float IoR = specData.extraParam.x;
+			float kappa = specData.extraParam.y;
+            float F_term = (specDesc.type == MatConductor) ? conductorFresnel(HoE, IoR, kappa) : 1.f - dielectricFresnel(HoE, IoR);
 			result.thp *= F_term;
 
 			result.effectiveRoughness = roughness;


### PR DESCRIPTION
To be clear, these *should* be allowed, but Slang passes through HLSL `const` as GLSL `const`, so it is easier to just drop `const` from our code for now to avoid issues.